### PR TITLE
feat(open-api): support application/x-www-form-urlencoded response content type (#219)

### DIFF
--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
@@ -50,7 +50,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Client.php
@@ -39,7 +39,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
@@ -2227,7 +2227,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Docker\Api\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Docker\Api\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client\
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client\
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
@@ -56,7 +56,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
@@ -18770,7 +18770,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php
@@ -53,7 +53,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php
@@ -43,7 +43,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Issue832\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
@@ -70,7 +70,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Client.php
@@ -164,7 +164,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
@@ -147,7 +147,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\C
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -39,7 +39,7 @@ class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -64,7 +64,7 @@ class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -75,7 +75,7 @@ class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
@@ -52,7 +52,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -252,6 +252,43 @@ EOD
                         'stmts' => [$returnStatement],
                     ]
                 );
+            } elseif ('application/x-www-form-urlencoded' === $baseContentType) {
+                [$returnType, $throwType, $returnStatement] = $this->createContentDenormalizationStatement(
+                    $name,
+                    $status,
+                    $content->getSchema(),
+                    $context,
+                    $reference . '/content/' . $contentType . '/schema',
+                    $description,
+                    $guessClass,
+                    $exceptionGenerator,
+                    'form'
+                );
+
+                if ($returnType !== null) {
+                    $returnTypes[] = $returnType;
+                }
+
+                if ($throwType !== null) {
+                    $throwTypes[] = $throwType;
+                }
+
+                $statements[] = new Stmt\If_(
+                    new Expr\BinaryOp\NotIdentical(
+                        new Expr\FuncCall(new Name('mb_strpos'), [
+                            new Node\Arg(
+                                new Expr\FuncCall(new Name('strtolower'), [
+                                    new Expr\Variable('contentType'),
+                                ]),
+                            ),
+                            new Node\Arg(new Scalar\String_($baseContentType)),
+                        ]),
+                        new Expr\ConstFetch(new Name('false'))
+                    ),
+                    [
+                        'stmts' => [$returnStatement],
+                    ]
+                );
             }
         }
 
@@ -288,7 +325,7 @@ EOD
         )]];
     }
 
-    private function createContentDenormalizationStatement(string $name, string $status, $schema, Context $context, string $reference, string $description, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator): array
+    private function createContentDenormalizationStatement(string $name, string $status, $schema, Context $context, string $reference, string $description, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, string $format = 'json'): array
     {
         $originalSchema = $schema;
         $classGuess = $guessClass->guessClass($schema, $reference, $context->getRegistry(), $array);
@@ -319,7 +356,7 @@ EOD
                 [
                     new Node\Arg(new Expr\Variable('body')),
                     new Node\Arg(new Scalar\String_($class)),
-                    new Node\Arg(new Scalar\String_('json')),
+                    new Node\Arg(new Scalar\String_($format)),
                 ]
             );
         } elseif ($schema instanceof Schema) {

--- a/src/Component/OpenApi3/Tests/CustomClientServerPathRuntimeTest.php
+++ b/src/Component/OpenApi3/Tests/CustomClientServerPathRuntimeTest.php
@@ -116,6 +116,7 @@ class CustomClientServerPathRuntimeTest extends TestCase
         require_once $dir . '/Runtime/Client/Endpoint.php';
         require_once $dir . '/Runtime/Client/EndpointTrait.php';
         require_once $dir . '/Runtime/Client/BaseEndpoint.php';
+        require_once $dir . '/Runtime/Client/FormEncoder.php';
         require_once $dir . '/Runtime/Normalizer/CheckArray.php';
         require_once $dir . '/Runtime/Normalizer/ValidatorTrait.php';
         require_once $dir . '/Runtime/Normalizer/ReferenceNormalizer.php';

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected.manifest.json
@@ -2,7 +2,7 @@
     "algorithm": "sha256",
     "files": {
         "Authentication/ApiKeyAuthentication.php": "7a73abbf8059070a5e8a63387cd2b27a67fe71aeaea19a8204b797f97160c74d",
-        "Client.php": "8bb1b672380b7ccfa32fd62507926333732693782fcb3c23809540fe5fc087fd",
+        "Client.php": "500d2dd939c1e23eb9b49f07161ab7aad0a8d7c3a4cd3ba6dff3af55118aee64",
         "Endpoint/ApiBooksBookIdreviewsGetCollection.php": "c6ac605df2a4fc1fb2f15f64b616aa6a99eb19efeeaa76478106857a37040fa8",
         "Endpoint/ApiBooksGetCollection.php": "7e140dd4e80e53c164b5cb441f7d5a050e3abb64bea21153a790ca91d16280c8",
         "Endpoint/ApiBooksIdDelete.php": "f7164fbd4c199a84b31e113fb0715594dad3b86cdc893584293fa16d51e43f63",

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
@@ -52,7 +52,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\C
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
@@ -50,7 +50,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Client.php
@@ -39,7 +39,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client\
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client\
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
@@ -57,7 +57,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected.manifest.json
@@ -1,7 +1,7 @@
 {
     "algorithm": "sha256",
     "files": {
-        "Client.php": "8fa1599d873bfc73f19f451ddd124463d6a4eeae91bdc6be30f29d948a43bc5f",
+        "Client.php": "ecbde58cd62856bbef44807240167c8ef5ef2c2af92c83db59531073f30f772d",
         "Endpoint/ActionsAddSelectedRepoToOrgSecret.php": "375fd1cc49465cadecef863d12bf3d4e5bbc5372caf29e0b0a4b96018664d70d",
         "Endpoint/ActionsCancelWorkflowRun.php": "a10aa11eed0facf1dcaf6b6d6093ed546499edc9d269129bd83b33fd6257add4",
         "Endpoint/ActionsCreateOrUpdateOrgSecret.php": "1f6692c8125006fe7e85d5d04a29aa833b2587fa2eae0de59549c3fafa97055f",

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedIssue1036\Runtime\Cl
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\ExpectedIssue1036\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ExpectedIssue1036\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
@@ -39,7 +39,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
@@ -1216,7 +1216,7 @@ class Client extends \CreditSafe\API\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \CreditSafe\API\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace CreditSafe\API\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CreditSafe\API\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace CreditSafe\API\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CreditSafe\API\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Gounlaf\JanephpBug\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Gounlaf\JanephpBug\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
@@ -3938,7 +3938,7 @@ class Client extends \PicturePark\API\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \PicturePark\API\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace PicturePark\API\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PicturePark\API\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PicturePark\API\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PicturePark\API\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PicturePark\API\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PicturePark\API\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PicturePark\API\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PicturePark\API\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PicturePark\API\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php
@@ -37,7 +37,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
@@ -10341,7 +10341,7 @@ class Client extends \Jane\Generated\DigitalOcean\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Generated\DigitalOcean\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Generated\DigitalOcean\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php
@@ -77,7 +77,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Issue680\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Issue680\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue680\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php
@@ -42,7 +42,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedIssue793\Runtime\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\ExpectedIssue793\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ExpectedIssue793\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
@@ -42,7 +42,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
@@ -31,7 +31,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Issue823\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
@@ -61,7 +61,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Run
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Client.php
@@ -164,7 +164,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
@@ -36,7 +36,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -187,7 +187,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
@@ -48,7 +48,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\C
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
@@ -92,7 +92,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php
@@ -33,7 +33,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
@@ -31,7 +31,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected.manifest.json
@@ -1,7 +1,7 @@
 {
     "algorithm": "sha256",
     "files": {
-        "Client.php": "5432e47dd8536e99a70b3c3df470fa793d403fa709a68266ce234b2f6ca11e41",
+        "Client.php": "af8c5a25d17e4222c4273ffe3bdd899608b965b794b48436c05c2be4d8063ae9",
         "Endpoint/AddOrDeleteRules.php": "e81c3d506fced57ebd78d2bb367f358ff2b694db06dcef55e631b5d229923bfa",
         "Endpoint/FindPrivateTweetMetricsById.php": "015edd6767d1943f94cb12fccdbbf52074f763ce81d9a7913213f513469af778",
         "Endpoint/FindTweetsById.php": "c013a41acfa86ae62fad988af5103d39d6411262d7a421a1e5d51d31676bbce2",

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -58,7 +58,7 @@ class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php
@@ -38,7 +38,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -58,7 +58,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
@@ -52,7 +52,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/WhitelistedSchema.php
+++ b/src/Component/OpenApi3/WhitelistedSchema.php
@@ -111,7 +111,7 @@ class WhitelistedSchema implements WhitelistFetchInterface
             foreach ($response->getContent() as $contentType => $content) {
                 $baseContentType = ContentType::withoutParameters($contentType);
 
-                if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
+                if (\in_array($baseContentType, ['application/json', 'application/x-www-form-urlencoded'], true) || str_ends_with($baseContentType, '+json')) {
                     $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
                     $schema = $content->getSchema();
                     $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);

--- a/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -251,6 +251,43 @@ EOD
                         'stmts' => [$returnStatement],
                     ]
                 );
+            } elseif ('application/x-www-form-urlencoded' === $baseContentType) {
+                [$returnType, $throwType, $returnStatement] = $this->createContentDenormalizationStatement(
+                    $name,
+                    $status,
+                    $content->getSchema(),
+                    $context,
+                    $reference . '/content/' . $contentType . '/schema',
+                    $description,
+                    $guessClass,
+                    $exceptionGenerator,
+                    'form'
+                );
+
+                if ($returnType !== null) {
+                    $returnTypes[] = $returnType;
+                }
+
+                if ($throwType !== null) {
+                    $throwTypes[] = $throwType;
+                }
+
+                $statements[] = new Stmt\If_(
+                    new Expr\BinaryOp\NotIdentical(
+                        new Expr\FuncCall(new Name('mb_strpos'), [
+                            new Node\Arg(
+                                new Expr\FuncCall(new Name('strtolower'), [
+                                    new Expr\Variable('contentType'),
+                                ]),
+                            ),
+                            new Node\Arg(new Scalar\String_($baseContentType)),
+                        ]),
+                        new Expr\ConstFetch(new Name('false'))
+                    ),
+                    [
+                        'stmts' => [$returnStatement],
+                    ]
+                );
             }
         }
 
@@ -286,7 +323,7 @@ EOD
         )]];
     }
 
-    private function createContentDenormalizationStatement(string $name, string $status, $schema, Context $context, string $reference, string $description, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator): array
+    private function createContentDenormalizationStatement(string $name, string $status, $schema, Context $context, string $reference, string $description, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, string $format = 'json'): array
     {
         $originalSchema = $schema;
         $classGuess = $guessClass->guessClass($schema, $reference, $context->getRegistry(), $array);
@@ -317,7 +354,7 @@ EOD
                 [
                     new Node\Arg(new Expr\Variable('body')),
                     new Node\Arg(new Scalar\String_($class)),
-                    new Node\Arg(new Scalar\String_('json')),
+                    new Node\Arg(new Scalar\String_($format)),
                 ]
             );
         } elseif ($schema instanceof JsonSchema) {

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
@@ -25,7 +25,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runti
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Clien
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Issue1006\Runtime\Client\Cl
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Issue1006\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Issue1006\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php
@@ -30,7 +30,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Runtime\C
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php
@@ -39,7 +39,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
@@ -36,7 +36,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
@@ -147,7 +147,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
@@ -29,7 +29,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
@@ -167,7 +167,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
@@ -57,7 +57,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
@@ -166,7 +166,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
@@ -52,7 +52,7 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/WhitelistedSchema.php
+++ b/src/Component/OpenApi31/WhitelistedSchema.php
@@ -95,7 +95,7 @@ class WhitelistedSchema implements WhitelistFetchInterface
             foreach ($response->getContent() as $contentType => $content) {
                 $baseContentType = ContentType::withoutParameters($contentType);
 
-                if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
+                if (\in_array($baseContentType, ['application/json', 'application/x-www-form-urlencoded'], true) || str_ends_with($baseContentType, '+json')) {
                     $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
                     $schema = $content->getSchema();
                     $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);

--- a/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
@@ -114,6 +114,9 @@ trait ClientGenerator
                                                 ])),
                                             ])
                                         ),
+                                        new Expr\ArrayItem(
+                                            new Expr\New_(new Name('\\' . $context->getCurrentSchema()->getNamespace() . '\\Runtime\\Client\\FormEncoder'))
+                                        ),
                                     ])
                                 ),
                             ]

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/FormEncoder.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/FormEncoder.php
@@ -1,0 +1,40 @@
+<?php
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+
+        return $result;
+    }
+
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}


### PR DESCRIPTION
## Description

Support `application/x-www-form-urlencoded` as a response content type in generated endpoints. Previously, Jane only handled this content type for request bodies; responses with `application/x-www-form-urlencoded` were silently ignored and not deserialized into model objects.

## Changes

- **New `FormEncoder` runtime class** — a Symfony Serializer `EncoderInterface`/`DecoderInterface` for the `form` format, using `parse_str()` for decoding and `http_build_query()` for encoding. This mirrors how `JsonEncoder` is used for the `json` format.
- **Register `FormEncoder` in generated clients** — the `ClientGenerator` now adds a `FormEncoder` instance to the encoder array in the generated `Client::create()` factory method.
- **Response deserialization wiring** — `GetTransformResponseBodyTrait` now handles `application/x-www-form-urlencoded` responses by calling `$serializer->deserialize($body, $class, 'form')`, which goes through the new `FormEncoder` to parse the form-encoded body into an array and then denormalize it into the target model.
- **WhitelistedSchema update** — `WhitelistedSchema::addResponseRelations()` now includes `application/x-www-form-urlencoded` alongside `application/json` so that model classes referenced in form-urlencoded responses are properly registered.
- **Updated fixture baselines** — all component test fixtures regenerated to include the `FormEncoder` in their `Client.php` output and deploy the runtime file.

## How to test

1. `composer install`
2. `vendor/bin/phpunit` — all 686+ tests pass
3. `castor qa:phpstan` — no errors

## Notes

- OpenAPI 2 is unaffected — it does not use content-typed responses.
- `multipart/form-data` responses are not covered by this change and could be handled in a follow-up.
