### PR TITLE
feat(tests): syntax gate — parse generated fixture output with php-parser before comparing

### DIFF
--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -44,6 +44,14 @@ of the templates shipped in `Generator/Runtime/data` and are identical for every
 asserted once per component, by the dedicated `runtime-boilerplate` fixture (which opts back into full comparison via
 a `.full-compare` marker file). This keeps template changes from rippling into every fixture diff.
 
+### Syntax gate
+
+Before any baseline comparison, every generated `*.php` file is parsed with nikic/php-parser: matching a baseline only
+proves the output did not change, not that it is valid PHP. A fixture that reproduces a known generator bug emitting
+invalid PHP carries a `.known-invalid-php` marker file (its content links to the tracking issue). For those fixtures the
+gate asserts the output still *fails* to parse — once the bug is fixed, the marker file must be deleted along with
+refreshing the baseline.
+
 > **Important:** a few fixtures are *executed* by functional tests (their classes are loaded at runtime, through the
 > composer classmap or explicit `require_once`). Those fixtures keep their full `expected/` trees, including `Runtime/`
 > copies: currently `multi-namespace` (JsonSchema), `docker-api`, `issue-793`, `bad-response-exception`,

--- a/src/Component/JsonSchema/Tests/FixtureComparisonTrait.php
+++ b/src/Component/JsonSchema/Tests/FixtureComparisonTrait.php
@@ -2,11 +2,20 @@
 
 namespace Jane\Component\JsonSchema\Tests;
 
+use PhpParser\Error;
+use PhpParser\ParserFactory;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Shared comparison logic for fixture-based generator tests.
+ *
+ * Every generated PHP file is first run through the php-parser syntax gate:
+ * matching a baseline only proves the output did not change, not that it is
+ * valid PHP. Fixtures reproducing a known generator bug that emits invalid
+ * PHP carry a `.known-invalid-php` marker file (content: link to the tracking
+ * issue); for those the gate asserts the output still fails to parse, so the
+ * marker must be deleted once the bug is fixed.
  *
  * Two baseline modes per fixture directory:
  *  - directory mode (default): committed `expected/` tree compared with the
@@ -21,6 +30,8 @@ trait FixtureComparisonTrait
 {
     private function assertFixtureMatchesGenerated(string $testDirectory): void
     {
+        $this->assertGeneratedFilesAreValidPhp($testDirectory);
+
         $manifestPath = $testDirectory . \DIRECTORY_SEPARATOR . 'expected.manifest.json';
 
         if (is_file($manifestPath)) {
@@ -30,6 +41,47 @@ trait FixtureComparisonTrait
         }
 
         $this->assertDirectoriesMatch($testDirectory);
+    }
+
+    private function assertGeneratedFilesAreValidPhp(string $testDirectory): void
+    {
+        $generatedDirectory = $testDirectory . \DIRECTORY_SEPARATOR . 'generated';
+
+        if (!is_dir($generatedDirectory)) {
+            return;
+        }
+
+        $parser = (new ParserFactory())->createForHostVersion();
+        $errors = [];
+
+        $finder = new Finder();
+        $finder->in($generatedDirectory)->files()->name('*.php');
+
+        foreach ($finder as $generatedFile) {
+            try {
+                $parser->parse(file_get_contents($generatedFile->getRealPath()));
+            } catch (Error $error) {
+                $errors[] = \sprintf('%s: %s', $generatedFile->getRelativePathname(), $error->getMessage());
+            }
+        }
+
+        $fixtureName = basename($testDirectory);
+
+        if (is_file($testDirectory . \DIRECTORY_SEPARATOR . '.known-invalid-php')) {
+            $this->assertNotSame(
+                [],
+                $errors,
+                \sprintf('Generated output for %s parses again: delete its stale .known-invalid-php marker', $fixtureName)
+            );
+
+            return;
+        }
+
+        $this->assertSame(
+            [],
+            $errors,
+            \sprintf('Generated files are not valid PHP for %s%s%s', $fixtureName, "\n", implode("\n", $errors))
+        );
     }
 
     /**

--- a/src/Component/JsonSchema/Tests/FixtureComparisonTraitTest.php
+++ b/src/Component/JsonSchema/Tests/FixtureComparisonTraitTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FixtureComparisonTraitTest extends TestCase
+{
+    use FixtureComparisonTrait;
+
+    private string $testDirectory;
+
+    protected function setUp(): void
+    {
+        $this->testDirectory = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . uniqid('jane-fixture-comparison-test-', true);
+        mkdir($this->testDirectory . \DIRECTORY_SEPARATOR . 'generated', 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->testDirectory);
+    }
+
+    public function testDirectoryModeFailsWhenGeneratedFileIsNotValidPhp(): void
+    {
+        // Identical on both sides: pure content comparison would pass.
+        $brokenPhp = "<?php\n\nclass Broken\n{\n    public function oops(\n}\n";
+        $this->writeFile('generated/Model/Broken.php', $brokenPhp);
+        mkdir($this->testDirectory . \DIRECTORY_SEPARATOR . 'expected' . \DIRECTORY_SEPARATOR . 'Model', 0o777, true);
+        $this->writeFile('expected/Model/Broken.php', $brokenPhp);
+
+        try {
+            $this->assertFixtureMatchesGenerated($this->testDirectory);
+        } catch (AssertionFailedError $failure) {
+            $this->assertStringContainsString('Model/Broken.php', $failure->getMessage());
+            $this->assertStringContainsString('Syntax error', $failure->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected the syntax gate to reject a generated file that does not parse.');
+    }
+
+    public function testManifestModeFailsWhenGeneratedFileIsNotValidPhp(): void
+    {
+        $brokenPhp = "<?php\n\nreturn [1 =>;\n";
+        $this->writeFile('generated/Client.php', $brokenPhp);
+        $this->writeFile('expected.manifest.json', json_encode([
+            'algorithm' => 'sha256',
+            'files' => ['Client.php' => hash('sha256', $brokenPhp)],
+        ]));
+
+        try {
+            $this->assertFixtureMatchesGenerated($this->testDirectory);
+        } catch (AssertionFailedError $failure) {
+            $this->assertStringContainsString('Client.php', $failure->getMessage());
+            $this->assertStringContainsString('Syntax error', $failure->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected the syntax gate to reject a generated file that does not parse.');
+    }
+
+    public function testKnownInvalidMarkerTurnsParseFailureIntoPass(): void
+    {
+        $brokenPhp = "<?php\n\nclass Broken\n{\n    public function oops(\n}\n";
+        $this->writeFile('generated/Model/Broken.php', $brokenPhp);
+        $this->writeFile('expected/Model/Broken.php', $brokenPhp);
+        $this->writeFile('.known-invalid-php', "Tracked in https://github.com/janephp/janephp/issues/0\n");
+
+        $this->assertFixtureMatchesGenerated($this->testDirectory);
+    }
+
+    public function testKnownInvalidMarkerFailsOnceOutputParsesAgain(): void
+    {
+        $validPhp = "<?php\n\nclass Fine\n{\n}\n";
+        $this->writeFile('generated/Model/Fine.php', $validPhp);
+        $this->writeFile('expected/Model/Fine.php', $validPhp);
+        $this->writeFile('.known-invalid-php', "Tracked in https://github.com/janephp/janephp/issues/0\n");
+
+        try {
+            $this->assertFixtureMatchesGenerated($this->testDirectory);
+        } catch (AssertionFailedError $failure) {
+            $this->assertStringContainsString('.known-invalid-php', $failure->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected a stale .known-invalid-php marker to fail the fixture once its output parses again.');
+    }
+
+    public function testPassesWhenGeneratedFilesAreValidPhp(): void
+    {
+        $validPhp = "<?php\n\nclass Fine\n{\n}\n";
+        $this->writeFile('generated/Model/Fine.php', $validPhp);
+        $this->writeFile('generated/.gitignore', "*\n");
+        mkdir($this->testDirectory . \DIRECTORY_SEPARATOR . 'expected' . \DIRECTORY_SEPARATOR . 'Model', 0o777, true);
+        $this->writeFile('expected/Model/Fine.php', $validPhp);
+        $this->writeFile('expected/.gitignore', "*\n");
+
+        $this->assertFixtureMatchesGenerated($this->testDirectory);
+    }
+
+    private function writeFile(string $relativePath, string $content): void
+    {
+        $absolutePath = $this->testDirectory . \DIRECTORY_SEPARATOR . str_replace('/', \DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!is_dir(\dirname($absolutePath))) {
+            mkdir(\dirname($absolutePath), 0o777, true);
+        }
+
+        file_put_contents($absolutePath, $content);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/.known-invalid-php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/.known-invalid-php
@@ -1,0 +1,3 @@
+Known generator bug: path parameter regex constraints leak into PHP parameter
+names (e.g. `string $id:.+`), so the generated endpoints and client do not parse.
+Documented in https://github.com/janephp/janephp/issues/1041

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/.known-invalid-php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/.known-invalid-php
@@ -1,3 +1,3 @@
 Known generator bug: path parameter regex constraints leak into PHP parameter
 names (e.g. `string $id:.+`), so the generated endpoints and client do not parse.
-Documented in https://github.com/janephp/janephp/issues/1041
+Tracked in https://github.com/janephp/janephp/issues/1051

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/.known-invalid-php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/.known-invalid-php
@@ -1,0 +1,3 @@
+Known generator bug: a schema named `Parent` generates `class Parent`, which is
+a reserved PHP class name, so the generated model does not parse.
+Documented in https://github.com/janephp/janephp/issues/1041

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/.known-invalid-php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/.known-invalid-php
@@ -1,3 +1,3 @@
-Known generator bug: a schema named `Parent` generates `class Parent`, which is
+Known generator bug: a schema named `parent` generates `class Parent`, which is
 a reserved PHP class name, so the generated model does not parse.
-Documented in https://github.com/janephp/janephp/issues/1041
+Tracked in https://github.com/janephp/janephp/issues/1051


### PR DESCRIPTION
Implements the first rung of #1041 (maintainer feedback there: a php-parser check on generated code is a welcome addition).

## What

- Adds a **syntax gate** to `FixtureComparisonTrait`: before any baseline
  comparison, every generated `*.php` file is parsed with nikic/php-parser
  (already a core dependency, instantiated with the same
  `(new ParserFactory())->createForHostVersion()` idiom the generators use).
  One shared code path, so it covers every fixture of every component, in both
  baseline modes (directory and manifest).
- Adds a `.known-invalid-php` marker (content: link to the tracking issue) for
  fixtures reproducing a known generator bug that emits invalid PHP. For those
  fixtures the gate asserts the output still **fails** to parse, so a stale
  marker fails the suite and must be deleted the moment the bug is fixed.
- Unit-tests the trait itself (`FixtureComparisonTraitTest`): broken PHP is
  rejected in both baseline modes even when it matches the baseline, valid PHP
  passes, marker semantics in both directions.
- Documents the gate in `docs/contributing/tests.md`.

## Why

The fixture suite compares generated output against a baseline: that proves
the output did not *change*, not that it is *valid PHP*. A generator bug that
bakes broken syntax into both `generated/` and `expected/` passes today's
suite silently.

Not hypothetically: turning the gate on immediately flagged two committed
fixtures whose expected output does not parse —

- `OpenApi2/issue-770`: path parameter regex constraints leak into PHP
  parameter names (`/cluster/{id:.+}` → `public function __construct(string
  $id:.+, ...)`), breaking 3 endpoints and the client (`Syntax error,
  unexpected ':'`).
- `OpenApi3/referenced-request-bodies`: a schema named `parent` generates
  `class Parent` — a reserved PHP class name (`Cannot use 'Parent' as class
  name as it is reserved`).

Both carry the marker pointing at the tracking issue #1051 instead of blocking this PR.

## Validation

- `vendor/bin/phpunit --testsuite JsonSchema` — OK (includes the 5 new trait tests)
- Bare `vendor/bin/phpunit` — OK (695 tests, 38829 assertions): every fixture of
  every component passes the parser, except the two marked known-invalid ones
  which are asserted to keep failing until fixed
- Gate cost is negligible: full-suite wall time unchanged within noise
- PHPStan (2.2.2, repo config) — no errors; php-cs-fixer — no diff on touched files

---
Prepared with an AI agent (Claude Code); the gap was identified while hardening
generated clients for a production codebase, and all changes were verified by
running the test suite as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

