### PR TITLE
test(open-api): expand prism functional tests, add one for OpenAPI 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
         run: nohup prism mock src/Component/OpenApi3/Tests/client/openapi.yaml -p 4010 &
       - name: run OpenApi2 prism server
         run: nohup prism mock src/Component/OpenApi2/Tests/client/swagger.yaml -p 4011 &
+      - name: run OpenApi31 prism server
+        run: nohup prism mock src/Component/OpenApi31/Tests/client/openapi.yaml -p 4012 &
       - name: tests
         run: vendor/bin/phpunit --exclude-group none
   tests-lowest:
@@ -140,5 +142,7 @@ jobs:
         run: nohup prism mock src/Component/OpenApi3/Tests/client/openapi.yaml -p 4010 &
       - name: run OpenApi2 prism server
         run: nohup prism mock src/Component/OpenApi2/Tests/client/swagger.yaml -p 4011 &
+      - name: run OpenApi31 prism server
+        run: nohup prism mock src/Component/OpenApi31/Tests/client/openapi.yaml -p 4012 &
       - name: tests
         run: vendor/bin/phpunit --exclude-group none

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
         "psr-4": {
             "Jane\\Component\\JsonSchema\\Tests\\": "src/Component/JsonSchema/Tests/",
             "Jane\\Component\\OpenApi2\\Tests\\Client\\": "src/Component/OpenApi2/Tests/client/generated/",
-            "Jane\\Component\\OpenApi3\\Tests\\Client\\": "src/Component/OpenApi3/Tests/client/generated/"
+            "Jane\\Component\\OpenApi3\\Tests\\Client\\": "src/Component/OpenApi3/Tests/client/generated/",
+            "Jane\\Component\\OpenApi31\\Tests\\Client\\": "src/Component/OpenApi31/Tests/client/generated/"
         }
     },
     "bin": [

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -76,8 +76,9 @@ Fixtures holding a manifest are skipped by the replace-all script; use the task 
 By default, we don't run generated client related tests locally, because you need to run
 [stoplightio/prism](https://github.com/stoplightio/prism) with configuration as following:
 
-- `nohup prism mock -p 4010 -m src/OpenApi3/Tests/client/openapi.yaml &`
-- `nohup prism mock -p 4011 -m src/OpenApi2/Tests/client/swagger.yaml &`
+- `nohup prism mock -p 4010 -m src/Component/OpenApi3/Tests/client/openapi.yaml &`
+- `nohup prism mock -p 4011 -m src/Component/OpenApi2/Tests/client/swagger.yaml &`
+- `nohup prism mock -p 4012 -m src/Component/OpenApi31/Tests/client/openapi.yaml &`
 
 Both theses will run a "fake" API based on the given OpenApi scheme. If you want to see logs, you can remove `nohup`
 and `&` keywords on given commands.

--- a/src/Component/OpenApi2/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi2/Tests/JaneOpenApiResourceTest.php
@@ -2,19 +2,26 @@
 
 namespace Jane\Component\OpenApi2\Tests;
 
+use Http\Client\Common\Plugin\HeaderSetPlugin;
 use Jane\Component\JsonSchema\Tests\CodeStyleFixerTrait;
 use Jane\Component\JsonSchema\Tests\FixtureComparisonTrait;
 use Jane\Component\OpenApi2\Tests\Client\Authentication\ApiKeyAuthAuthentication;
 use Jane\Component\OpenApi2\Tests\Client\Client;
+use Jane\Component\OpenApi2\Tests\Client\Endpoint\GetThing;
 use Jane\Component\OpenApi2\Tests\Client\Exception\GetEndpointUnauthorizedException;
+use Jane\Component\OpenApi2\Tests\Client\Exception\GetThingNotFoundException;
 use Jane\Component\OpenApi2\Tests\Client\Model\Error;
 use Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse;
+use Jane\Component\OpenApi2\Tests\Client\Model\Thing;
+use Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails;
+use Jane\Component\OpenApi2\Tests\Client\Model\ThingInput;
 use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
 use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
 use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
 use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -87,6 +94,7 @@ class JaneOpenApiResourceTest extends TestCase
         $client = Client::create();
         try {
             $client->getEndpoint();
+            self::fail('Expected GetEndpointUnauthorizedException to be thrown.');
         } catch (GetEndpointUnauthorizedException $e) {
             $this->assertEquals(401, $e->getCode());
             $this->assertInstanceOf(Error::class, $e->getError());
@@ -96,5 +104,49 @@ class JaneOpenApiResourceTest extends TestCase
         $client = Client::create(null, [new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')])]);
         $response = $client->getEndpoint();
         $this->assertInstanceOf(SimpleResponse::class, $response);
+
+        // 4. Path and query parameters, enum, date format and array denormalization
+        $thing = $client->getThing('thing-1', ['q' => 'search', 'page' => 2]);
+        $this->assertInstanceOf(Thing::class, $thing);
+        $this->assertContains($thing->getKind(), ['created', 'updated', 'deleted']);
+        $this->assertInstanceOf(\DateTime::class, $thing->getCreatedAt());
+        $this->assertNotEmpty($thing->getTags());
+
+        // 5. JSON request body
+        $thingInput = new ThingInput();
+        $thingInput->setName('A thing');
+        $thingInput->setKind('created');
+        $createdThing = $client->createThing($thingInput);
+        $this->assertInstanceOf(Thing::class, $createdThing);
+
+        // 6. Form request body
+        $formThing = $client->createFormThing(['name' => 'A thing', 'kind' => 'created']);
+        $this->assertInstanceOf(Thing::class, $formThing);
+
+        // 7. allOf inheritance
+        $thingDetails = $client->getThingDetails('thing-1');
+        $this->assertInstanceOf(ThingDetails::class, $thingDetails);
+        $this->assertNotSame('', $thingDetails->getDescription());
+
+        // 8. 204 no content
+        $this->assertNull($client->deleteThing('thing-1'));
+
+        // 9. Raw PSR-7 response
+        $rawResponse = $client->executeRawEndpoint(new GetThing('thing-1', ['q' => 'search']));
+        $this->assertInstanceOf(ResponseInterface::class, $rawResponse);
+        $this->assertSame(200, $rawResponse->getStatusCode());
+
+        // 10. Typed exception on a 404 response selected through the Prefer header
+        $preferClient = Client::create(null, [
+            new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')]),
+            new HeaderSetPlugin(['Prefer' => 'code=404']),
+        ]);
+        try {
+            $preferClient->getThing('thing-1', ['q' => 'search']);
+            self::fail('Expected GetThingNotFoundException to be thrown.');
+        } catch (GetThingNotFoundException $e) {
+            $this->assertEquals(404, $e->getCode());
+            $this->assertInstanceOf(Error::class, $e->getError());
+        }
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Client.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Client.php
@@ -8,32 +8,94 @@ class Client extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\GetEndpointUnauthorizedException
      *
-     * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function getEndpoint(string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\GetEndpoint(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    /**
+     * @param \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput $body
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createThing(\Jane\Component\OpenApi2\Tests\Client\Model\ThingInput $body, string $fetch = self::FETCH_OBJECT)
     {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\CreateThing($body), $fetch);
+    }
+    /**
+     * @param array $formParameters {
+     *     @var string $name
+     *     @var string $kind
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createFormThing(array $formParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\CreateFormThing($formParameters), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function deleteThing(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\DeleteThing($thingId), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param array $queryParameters {
+     *     @var string $q
+     *     @var int $page
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThing(string $thingId, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\GetThing($thingId, $queryParameters), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThingDetails(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\GetThingDetails($thingId), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1:4011/');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Client\Normalizer\JaneObjectNormalizer()];
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/CreateFormThing.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/CreateFormThing.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
+
+class CreateFormThing extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param array $formParameters {
+     *     @var string $name
+     *     @var string $kind
+     * }
+     */
+    public function __construct(array $formParameters = [])
+    {
+        $this->formParameters = $formParameters;
+    }
+    use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things/form';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return $this->getFormBody();
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getFormOptionsResolver();
+        $optionsResolver->setDefined(['name', 'kind']);
+        $optionsResolver->setRequired(['name', 'kind']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('name', ['string']);
+        $optionsResolver->addAllowedTypes('kind', ['string']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Thing', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/CreateThing.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/CreateThing.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
+
+class CreateThing extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput $body
+     */
+    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\ThingInput $body)
+    {
+        $this->body = $body;
+    }
+    use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return $this->getSerializedObjectBody($serializer);
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (201 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Thing', 'json');
+        }
+        if (400 === $status) {
+            throw new \Jane\Component\OpenApi2\Tests\Client\Exception\CreateThingBadRequestException($serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/DeleteThing.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/DeleteThing.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
+
+class DeleteThing extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (204 === $status) {
+            return null;
+        }
+        if (404 === $status) {
+            throw new \Jane\Component\OpenApi2\Tests\Client\Exception\DeleteThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetThing.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetThing.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
+
+class GetThing extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     * @param array $queryParameters {
+     *     @var string $q
+     *     @var int $page
+     * }
+     */
+    public function __construct(string $thingId, array $queryParameters = [])
+    {
+        $this->thingId = $thingId;
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['q', 'page']);
+        $optionsResolver->setRequired(['q']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('q', ['string']);
+        $optionsResolver->addAllowedTypes('page', ['int']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi2\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Thing', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\Component\OpenApi2\Tests\Client\Exception\GetThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetThingDetails.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetThingDetails.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
+
+class GetThingDetails extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}/details');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/BadRequestException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/BadRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+abstract class BadRequestException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/CreateThingBadRequestException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/CreateThingBadRequestException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+class CreateThingBadRequestException extends BadRequestException
+{
+    /**
+     * @var \Jane\Component\OpenApi2\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Invalid input');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi2\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/DeleteThingNotFoundException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/DeleteThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+class DeleteThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi2\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi2\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/GetThingNotFoundException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/GetThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+class GetThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi2\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi2\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+abstract class NotFoundException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Client\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException, WithResponseInterface
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/WithResponseInterface.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/WithResponseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Exception;
+
+interface WithResponseInterface
+{
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface;
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Model/Thing.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Model/Thing.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Model;
+
+class Thing
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Model/ThingDetails.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Model/ThingDetails.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Model;
+
+class ThingDetails
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @var string
+     */
+    protected $description;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+    /**
+     * @param string $description
+     *
+     * @return self
+     */
+    public function setDescription(string $description): self
+    {
+        $this->initialized['description'] = true;
+        $this->description = $description;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Model/ThingInput.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Model/ThingInput.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Model;
+
+class ThingInput
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/ErrorNormalizer.php
@@ -27,15 +27,15 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Error();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('message', $data)) {
             $object->setMessage($data['message']);

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
@@ -22,6 +22,12 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ErrorNormalizer::class,
         
+        \Jane\Component\OpenApi2\Tests\Client\Model\Thing::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ThingNormalizer::class,
+        
+        \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ThingInputNormalizer::class,
+        
+        \Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ThingDetailsNormalizer::class,
+        
         \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
     ], $normalizersCache = [];
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
@@ -58,11 +64,6 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [
-            
-            \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => false,
-            \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => false,
-            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
-        ];
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
@@ -27,18 +27,18 @@ class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInter
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse();
         if (\array_key_exists('baz', $data) && \is_int($data['baz'])) {
             $data['baz'] = (bool) $data['baz'];
-        }
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('foo', $data)) {
             $object->setFoo($data['foo']);

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingDetailsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+        }
+        if (\array_key_exists('description', $data)) {
+            $object->setDescription($data['description']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        $dataArray['description'] = $data->getDescription();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Client\Model\ThingDetails::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingInputNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingInputNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingInputNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\ThingInput();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Client\Model\ThingInput::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/ThingNormalizer.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Client\Model\Thing::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\Thing::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Thing();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Client\Model\Thing::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/BaseEndpoint.php
@@ -24,10 +24,24 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
-        return http_build_query($optionsResolved, '', '&', \PHP_QUERY_RFC3986);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
     }
     public function getHeaders(array $baseHeaders = []): array
     {
@@ -43,12 +57,29 @@ abstract class BaseEndpoint implements Endpoint
             }
             $headerParameters[$name] = $value;
         }
-
         return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
     }
     protected function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
     }
     protected function getHeadersOptionsResolver(): OptionsResolver
     {
@@ -76,5 +107,179 @@ abstract class BaseEndpoint implements Endpoint
     protected function getSerializedBody(SerializerInterface $serializer): array
     {
         return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/CustomQueryResolver.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
-
-use Symfony\Component\OptionsResolver\Options;
-interface CustomQueryResolver
-{
-    public function __invoke(Options $options, $value);
-}

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/client/swagger.yaml
+++ b/src/Component/OpenApi2/Tests/client/swagger.yaml
@@ -24,6 +24,113 @@ paths:
             "$ref": "#/definitions/Error"
       produces:
         - application/json
+  "/things":
+    post:
+      summary: Create a thing
+      operationId: createThing
+      consumes:
+        - application/json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            "$ref": "#/definitions/ThingInput"
+      responses:
+        '201':
+          description: Thing created
+          schema:
+            "$ref": "#/definitions/Thing"
+        '400':
+          description: Invalid input
+          schema:
+            "$ref": "#/definitions/Error"
+      produces:
+        - application/json
+  "/things/form":
+    post:
+      summary: Create a thing from form data
+      operationId: createFormThing
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - name: name
+          in: formData
+          required: true
+          type: string
+        - name: kind
+          in: formData
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Thing created
+          schema:
+            "$ref": "#/definitions/Thing"
+      produces:
+        - application/json
+  "/things/{thingId}":
+    get:
+      summary: Get a thing
+      operationId: getThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          type: string
+        - name: q
+          in: query
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: Thing found
+          schema:
+            "$ref": "#/definitions/Thing"
+        '404':
+          description: Thing not found
+          schema:
+            "$ref": "#/definitions/Error"
+      produces:
+        - application/json
+    delete:
+      summary: Delete a thing
+      operationId: deleteThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Thing deleted
+        '404':
+          description: Thing not found
+          schema:
+            "$ref": "#/definitions/Error"
+      produces:
+        - application/json
+  "/things/{thingId}/details":
+    get:
+      summary: Get extended details of a thing
+      operationId: getThingDetails
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Extended thing details
+          schema:
+            "$ref": "#/definitions/ThingDetails"
+      produces:
+        - application/json
 definitions:
   SimpleResponse:
     type: object
@@ -37,6 +144,55 @@ definitions:
     properties:
       message:
         type: string
+  Thing:
+    type: object
+    required:
+      - id
+      - name
+      - kind
+      - createdAt
+      - tags
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      kind:
+        type: string
+        enum:
+          - created
+          - updated
+          - deleted
+      createdAt:
+        type: string
+        format: date
+      tags:
+        type: array
+        items:
+          type: string
+  ThingInput:
+    type: object
+    required:
+      - name
+      - kind
+    properties:
+      name:
+        type: string
+      kind:
+        type: string
+        enum:
+          - created
+          - updated
+          - deleted
+  ThingDetails:
+    allOf:
+      - "$ref": "#/definitions/Thing"
+      - type: object
+        required:
+          - description
+        properties:
+          description:
+            type: string
 security:
   - ApiKeyAuth: []
 securityDefinitions:

--- a/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
@@ -2,19 +2,26 @@
 
 namespace Jane\Component\OpenApi3\Tests;
 
+use Http\Client\Common\Plugin\HeaderSetPlugin;
 use Jane\Component\JsonSchema\Tests\CodeStyleFixerTrait;
 use Jane\Component\JsonSchema\Tests\FixtureComparisonTrait;
 use Jane\Component\OpenApi3\Tests\Client\Authentication\ApiKeyAuthAuthentication;
 use Jane\Component\OpenApi3\Tests\Client\Client;
+use Jane\Component\OpenApi3\Tests\Client\Endpoint\GetThing;
 use Jane\Component\OpenApi3\Tests\Client\Exception\GetEndpointUnauthorizedException;
+use Jane\Component\OpenApi3\Tests\Client\Exception\GetThingNotFoundException;
 use Jane\Component\OpenApi3\Tests\Client\Model\Error;
 use Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse;
+use Jane\Component\OpenApi3\Tests\Client\Model\Thing;
+use Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails;
+use Jane\Component\OpenApi3\Tests\Client\Model\ThingInput;
 use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
 use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
 use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
 use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -78,6 +85,7 @@ class JaneOpenApiResourceTest extends TestCase
         $client = Client::create();
         try {
             $client->getEndpoint();
+            self::fail('Expected GetEndpointUnauthorizedException to be thrown.');
         } catch (GetEndpointUnauthorizedException $e) {
             $this->assertEquals(401, $e->getCode());
             $this->assertInstanceOf(Error::class, $e->getError());
@@ -87,5 +95,49 @@ class JaneOpenApiResourceTest extends TestCase
         $client = Client::create(null, [new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')])]);
         $response = $client->getEndpoint();
         $this->assertInstanceOf(SimpleResponse::class, $response);
+
+        // 4. Path and query parameters, enum, date format and array denormalization
+        $thing = $client->getThing('thing-1', ['q' => 'search', 'page' => 2]);
+        $this->assertInstanceOf(Thing::class, $thing);
+        $this->assertContains($thing->getKind(), ['created', 'updated', 'deleted']);
+        $this->assertInstanceOf(\DateTime::class, $thing->getCreatedAt());
+        $this->assertNotEmpty($thing->getTags());
+
+        // 5. JSON request body
+        $thingInput = new ThingInput();
+        $thingInput->setName('A thing');
+        $thingInput->setKind('created');
+        $createdThing = $client->createThing($thingInput);
+        $this->assertInstanceOf(Thing::class, $createdThing);
+
+        // 6. Form request body
+        $formThing = $client->createFormThing($thingInput);
+        $this->assertInstanceOf(Thing::class, $formThing);
+
+        // 7. allOf inheritance
+        $thingDetails = $client->getThingDetails('thing-1');
+        $this->assertInstanceOf(ThingDetails::class, $thingDetails);
+        $this->assertNotSame('', $thingDetails->getDescription());
+
+        // 8. 204 no content
+        $this->assertNull($client->deleteThing('thing-1'));
+
+        // 9. Raw PSR-7 response
+        $rawResponse = $client->executeRawEndpoint(new GetThing('thing-1', ['q' => 'search']));
+        $this->assertInstanceOf(ResponseInterface::class, $rawResponse);
+        $this->assertSame(200, $rawResponse->getStatusCode());
+
+        // 10. Typed exception on a 404 response selected through the Prefer header
+        $preferClient = Client::create(null, [
+            new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')]),
+            new HeaderSetPlugin(['Prefer' => 'code=404']),
+        ]);
+        try {
+            $preferClient->getThing('thing-1', ['q' => 'search']);
+            self::fail('Expected GetThingNotFoundException to be thrown.');
+        } catch (GetThingNotFoundException $e) {
+            $this->assertEquals(404, $e->getCode());
+            $this->assertInstanceOf(Error::class, $e->getError());
+        }
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Client.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Client.php
@@ -8,32 +8,91 @@ class Client extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\GetEndpointUnauthorizedException
      *
-     * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function getEndpoint(string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\GetEndpoint(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    /**
+     * @param \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createThing(\Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody, string $fetch = self::FETCH_OBJECT)
     {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\CreateThing($requestBody), $fetch);
+    }
+    /**
+     * @param \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createFormThing(\Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\CreateFormThing($requestBody), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function deleteThing(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\DeleteThing($thingId), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param array{
+     *    "q": string,
+     *    "page"?: int,
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThing(string $thingId, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\GetThing($thingId, $queryParameters), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThingDetails(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\GetThingDetails($thingId), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1:4010/');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Client\Normalizer\JaneObjectNormalizer()];
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }
-        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\FormEncoder()]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/CreateFormThing.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/CreateFormThing.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
+
+class CreateFormThing extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody
+     */
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things/form';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput) {
+            return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($serializer->normalize($this->body, 'json'))];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Thing', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/CreateThing.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/CreateThing.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
+
+class CreateThing extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody
+     */
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\ThingInput $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput) {
+            return [['Content-Type' => ['application/json']], \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\JsonPayload::encode($serializer, $this->body)];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (201 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Thing', 'json');
+        }
+        if (is_null($contentType) === false && (400 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Client\Exception\CreateThingBadRequestException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/DeleteThing.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/DeleteThing.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
+
+class DeleteThing extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (204 === $status) {
+            return null;
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Client\Exception\DeleteThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetThing.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetThing.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
+
+class GetThing extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     * @param array{
+     *    "q": string,
+     *    "page"?: int,
+     * } $queryParameters
+     */
+    public function __construct(string $thingId, array $queryParameters = [])
+    {
+        $this->thingId = $thingId;
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['q', 'page']);
+        $optionsResolver->setRequired(['q']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('q', ['string']);
+        $optionsResolver->addAllowedTypes('page', ['int']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Thing', 'json');
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Client\Exception\GetThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetThingDetails.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetThingDetails.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
+
+class GetThingDetails extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}/details');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/BadRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+abstract class BadRequestException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/CreateThingBadRequestException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/CreateThingBadRequestException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+class CreateThingBadRequestException extends BadRequestException
+{
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Invalid input');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi3\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/DeleteThingNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/DeleteThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+class DeleteThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi3\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/GetThingNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/GetThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+class GetThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi3\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+abstract class NotFoundException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException, WithResponseInterface
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/WithResponseInterface.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/WithResponseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Exception;
+
+interface WithResponseInterface
+{
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface;
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Model/Error.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/Error.php
@@ -2,8 +2,11 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Model;
 
-class Error extends \ArrayObject
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class Error implements AdditionalPropertiesInterface
 {
+    use AdditionalAndPatternProperties;
     /**
      * @var array
      */
@@ -33,5 +36,9 @@ class Error extends \ArrayObject
         $this->initialized['message'] = true;
         $this->message = $message;
         return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['message' => ['message', 'getMessage', 'setMessage']];
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Model/SimpleResponse.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/SimpleResponse.php
@@ -2,8 +2,11 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Model;
 
-class SimpleResponse extends \ArrayObject
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class SimpleResponse implements AdditionalPropertiesInterface
 {
+    use AdditionalAndPatternProperties;
     /**
      * @var array
      */
@@ -55,5 +58,9 @@ class SimpleResponse extends \ArrayObject
         $this->initialized['baz'] = true;
         $this->baz = $baz;
         return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['foo' => ['foo', 'getFoo', 'setFoo'], 'baz' => ['baz', 'getBaz', 'setBaz']];
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Model/Thing.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/Thing.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Model;
+
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class Thing implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['id' => ['id', 'getId', 'setId'], 'name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind'], 'createdAt' => ['createdAt', 'getCreatedAt', 'setCreatedAt'], 'tags' => ['tags', 'getTags', 'setTags']];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Model/ThingDetails.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/ThingDetails.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Model;
+
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class ThingDetails implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @var string
+     */
+    protected $description;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+    /**
+     * @param string $description
+     *
+     * @return self
+     */
+    public function setDescription(string $description): self
+    {
+        $this->initialized['description'] = true;
+        $this->description = $description;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['id' => ['id', 'getId', 'setId'], 'name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind'], 'createdAt' => ['createdAt', 'getCreatedAt', 'setCreatedAt'], 'tags' => ['tags', 'getTags', 'setTags'], 'description' => ['description', 'getDescription', 'setDescription']];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Model/ThingInput.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/ThingInput.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Model;
+
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class ThingInput implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind']];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/ErrorNormalizer.php
@@ -27,15 +27,15 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Error();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('message', $data)) {
             $object->setMessage($data['message']);
@@ -54,7 +54,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if ($data->isInitialized('message') && null !== $data->getMessage()) {
             $dataArray['message'] = $data->getMessage();
         }
-        foreach ($data as $key => $value) {
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
             if (preg_match('/.*/', (string) $key)) {
                 $dataArray[$key] = $value;
             }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
@@ -22,6 +22,12 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ErrorNormalizer::class,
         
+        \Jane\Component\OpenApi3\Tests\Client\Model\Thing::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ThingNormalizer::class,
+        
+        \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ThingInputNormalizer::class,
+        
+        \Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ThingDetailsNormalizer::class,
+        
         \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
     ], $normalizersCache = [];
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
@@ -58,11 +64,6 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [
-            
-            \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => false,
-            \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => false,
-            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
-        ];
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
@@ -27,18 +27,18 @@ class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInter
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse();
         if (\array_key_exists('baz', $data) && \is_int($data['baz'])) {
             $data['baz'] = (bool) $data['baz'];
-        }
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('foo', $data)) {
             $object->setFoo($data['foo']);
@@ -64,7 +64,7 @@ class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInter
         if ($data->isInitialized('baz') && null !== $data->getBaz()) {
             $dataArray['baz'] = $data->getBaz();
         }
-        foreach ($data as $key => $value) {
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
             if (preg_match('/.*/', (string) $key)) {
                 $dataArray[$key] = $value;
             }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingDetailsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+            unset($data['createdAt']);
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+            unset($data['tags']);
+        }
+        if (\array_key_exists('description', $data)) {
+            $object->setDescription($data['description']);
+            unset($data['description']);
+        }
+        foreach ($data as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value_1;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        $dataArray['description'] = $data->getDescription();
+        foreach ($data->additionalPropertyEntries() as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value_1;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Client\Model\ThingDetails::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingInputNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingInputNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingInputNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\ThingInput();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Client\Model\ThingInput::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/ThingNormalizer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Client\Model\Thing::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\Thing::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Thing();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+            unset($data['createdAt']);
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+            unset($data['tags']);
+        }
+        foreach ($data as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value_1;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        foreach ($data->additionalPropertyEntries() as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value_1;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Client\Model\Thing::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/BaseEndpoint.php
@@ -24,10 +24,24 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
-        return http_build_query($optionsResolved, '', '&', \PHP_QUERY_RFC3986);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
     }
     public function getHeaders(array $baseHeaders = []): array
     {
@@ -43,12 +57,29 @@ abstract class BaseEndpoint implements Endpoint
             }
             $headerParameters[$name] = $value;
         }
-
         return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
     }
     protected function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
     }
     protected function getHeadersOptionsResolver(): OptionsResolver
     {
@@ -76,5 +107,179 @@ abstract class BaseEndpoint implements Endpoint
     protected function getSerializedBody(SerializerInterface $serializer): array
     {
         return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/CustomQueryResolver.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
-
-use Symfony\Component\OptionsResolver\Options;
-interface CustomQueryResolver
-{
-    public function __invoke(Options $options, $value);
-}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/client/openapi.yaml
+++ b/src/Component/OpenApi3/Tests/client/openapi.yaml
@@ -26,8 +26,114 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-security:
-  - ApiKeyAuth: []
+  /things:
+    post:
+      summary: Create a thing
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThingInput'
+      responses:
+        '201':
+          description: Thing created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /things/form:
+    post:
+      summary: Create a thing from form data
+      operationId: createFormThing
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ThingInput'
+      responses:
+        '200':
+          description: Thing created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+  /things/{thingId}:
+    get:
+      summary: Get a thing
+      operationId: getThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Thing found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '404':
+          description: Thing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete a thing
+      operationId: deleteThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Thing deleted
+        '404':
+          description: Thing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /things/{thingId}/details:
+    get:
+      summary: Get extended details of a thing
+      operationId: getThingDetails
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Extended thing details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingDetails'
 components:
   schemas:
     SimpleResponse:
@@ -42,8 +148,59 @@ components:
       properties:
         message:
           type: string
+    Thing:
+      type: object
+      required:
+        - id
+        - name
+        - kind
+        - createdAt
+        - tags
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        kind:
+          type: string
+          enum:
+            - created
+            - updated
+            - deleted
+        createdAt:
+          type: string
+          format: date
+        tags:
+          type: array
+          items:
+            type: string
+    ThingInput:
+      type: object
+      required:
+        - name
+        - kind
+      properties:
+        name:
+          type: string
+        kind:
+          type: string
+          enum:
+            - created
+            - updated
+            - deleted
+    ThingDetails:
+      allOf:
+        - $ref: '#/components/schemas/Thing'
+        - type: object
+          required:
+            - description
+          properties:
+            description:
+              type: string
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-API-Key
+security:
+  - ApiKeyAuth: []

--- a/src/Component/OpenApi31/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi31/Tests/JaneOpenApiResourceTest.php
@@ -2,13 +2,26 @@
 
 namespace Jane\Component\OpenApi31\Tests;
 
+use Http\Client\Common\Plugin\HeaderSetPlugin;
 use Jane\Component\JsonSchema\Tests\CodeStyleFixerTrait;
 use Jane\Component\JsonSchema\Tests\FixtureComparisonTrait;
+use Jane\Component\OpenApi31\Tests\Client\Authentication\ApiKeyAuthAuthentication;
+use Jane\Component\OpenApi31\Tests\Client\Client;
+use Jane\Component\OpenApi31\Tests\Client\Endpoint\GetThing;
+use Jane\Component\OpenApi31\Tests\Client\Exception\GetEndpointUnauthorizedException;
+use Jane\Component\OpenApi31\Tests\Client\Exception\GetThingNotFoundException;
+use Jane\Component\OpenApi31\Tests\Client\Model\Error;
+use Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse;
+use Jane\Component\OpenApi31\Tests\Client\Model\Thing;
+use Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails;
+use Jane\Component\OpenApi31\Tests\Client\Model\ThingInput;
 use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
 use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
 use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
 use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
@@ -52,5 +65,75 @@ class JaneOpenApiResourceTest extends TestCase
         }
 
         return $data;
+    }
+
+    /**
+     * @group prism
+     */
+    public function testClient(): void
+    {
+        // 1. Generate
+        $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+        $input = new ArrayInput(['--config-file' => __DIR__ . '/client' . \DIRECTORY_SEPARATOR . '.jane-openapi'], $command->getDefinition());
+        $command->execute($input, new NullOutput());
+
+        // 2. Test unauthorized
+        $client = Client::create();
+        try {
+            $client->getEndpoint();
+            self::fail('Expected GetEndpointUnauthorizedException to be thrown.');
+        } catch (GetEndpointUnauthorizedException $exception) {
+            $this->assertEquals(401, $exception->getCode());
+            $this->assertInstanceOf(Error::class, $exception->getError());
+        }
+
+        // 3. Simple authenticated call
+        $client = Client::create(null, [new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')])]);
+        $response = $client->getEndpoint();
+        $this->assertInstanceOf(SimpleResponse::class, $response);
+
+        // 4. Path and query parameters, enum, date format and array denormalization
+        $thing = $client->getThing('thing-1', ['q' => 'search', 'page' => 2]);
+        $this->assertInstanceOf(Thing::class, $thing);
+        $this->assertContains($thing->getKind(), ['created', 'updated', 'deleted']);
+        $this->assertInstanceOf(\DateTime::class, $thing->getCreatedAt());
+        $this->assertNotEmpty($thing->getTags());
+
+        // 5. JSON request body
+        $thingInput = new ThingInput();
+        $thingInput->setName('A thing');
+        $thingInput->setKind('created');
+        $createdThing = $client->createThing($thingInput);
+        $this->assertInstanceOf(Thing::class, $createdThing);
+
+        // 6. Form request body
+        $formThing = $client->createFormThing($thingInput);
+        $this->assertInstanceOf(Thing::class, $formThing);
+
+        // 7. allOf inheritance
+        $thingDetails = $client->getThingDetails('thing-1');
+        $this->assertInstanceOf(ThingDetails::class, $thingDetails);
+        $this->assertNotSame('', $thingDetails->getDescription());
+
+        // 8. 204 no content
+        $this->assertNull($client->deleteThing('thing-1'));
+
+        // 9. Raw PSR-7 response
+        $rawResponse = $client->executeRawEndpoint(new GetThing('thing-1', ['q' => 'search']));
+        $this->assertInstanceOf(ResponseInterface::class, $rawResponse);
+        $this->assertSame(200, $rawResponse->getStatusCode());
+
+        // 10. Typed exception on a 404 response selected through the Prefer header
+        $preferClient = Client::create(null, [
+            new AuthenticationRegistry([new ApiKeyAuthAuthentication('api_key')]),
+            new HeaderSetPlugin(['Prefer' => 'code=404']),
+        ]);
+        try {
+            $preferClient->getThing('thing-1', ['q' => 'search']);
+            self::fail('Expected GetThingNotFoundException to be thrown.');
+        } catch (GetThingNotFoundException $exception) {
+            $this->assertEquals(404, $exception->getCode());
+            $this->assertInstanceOf(Error::class, $exception->getError());
+        }
     }
 }

--- a/src/Component/OpenApi31/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Authentication;
+
+class ApiKeyAuthAuthentication implements \Jane\Component\OpenApiRuntime\Client\AuthenticationPlugin
+{
+    private $apiKey;
+    public function __construct(string $apiKey)
+    {
+        $this->{'apiKey'} = $apiKey;
+    }
+    public function authentication(\Psr\Http\Message\RequestInterface $request): \Psr\Http\Message\RequestInterface
+    {
+        $request = $request->withHeader('X-API-Key', $this->{'apiKey'});
+        return $request;
+    }
+    public function getScope(): string
+    {
+        return 'ApiKeyAuth';
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Client.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Client.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\GetEndpointUnauthorizedException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getEndpoint(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\GetEndpoint(), $fetch);
+    }
+    /**
+     * @param \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createThing(\Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\CreateThing($requestBody), $fetch);
+    }
+    /**
+     * @param \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function createFormThing(\Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\CreateFormThing($requestBody), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function deleteThing(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\DeleteThing($thingId), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param array{
+     *    "q": string,
+     *    "page"?: int,
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThing(string $thingId, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\GetThing($thingId, $queryParameters), $fetch);
+    }
+    /**
+     * @param string $thingId
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getThingDetails(string $thingId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Client\Endpoint\GetThingDetails($thingId), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+        }
+        if ($applyServerPlugins) {
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1:4012/');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+        }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Client\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true])), new \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\FormEncoder()]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/CreateFormThing.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/CreateFormThing.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class CreateFormThing extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody
+     */
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things/form';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput) {
+            return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($serializer->normalize($this->body, 'json'))];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Thing', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/CreateThing.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/CreateThing.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class CreateThing extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    /**
+     * @param \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody
+     */
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\ThingInput $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/things';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput) {
+            return [['Content-Type' => ['application/json']], \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\JsonPayload::encode($serializer, $this->body)];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\CreateThingBadRequestException
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (201 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Thing', 'json');
+        }
+        if (is_null($contentType) === false && (400 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi31\Tests\Client\Exception\CreateThingBadRequestException($serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/DeleteThing.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/DeleteThing.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class DeleteThing extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\DeleteThingNotFoundException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (204 === $status) {
+            return null;
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi31\Tests\Client\Exception\DeleteThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetEndpoint.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetEndpoint.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class GetEndpoint extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/endpoint';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\GetEndpointUnauthorizedException
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse', 'json');
+        }
+        if (is_null($contentType) === false && (401 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi31\Tests\Client\Exception\GetEndpointUnauthorizedException($serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetThing.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetThing.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class GetThing extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     * @param array{
+     *    "q": string,
+     *    "page"?: int,
+     * } $queryParameters
+     */
+    public function __construct(string $thingId, array $queryParameters = [])
+    {
+        $this->thingId = $thingId;
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['q', 'page']);
+        $optionsResolver->setRequired(['q']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('q', ['string']);
+        $optionsResolver->addAllowedTypes('page', ['int']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi31\Tests\Client\Exception\GetThingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Client\Model\Thing
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Thing', 'json');
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi31\Tests\Client\Exception\GetThingNotFoundException($serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\Error', 'json'), $response);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetThingDetails.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Endpoint/GetThingDetails.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Endpoint;
+
+class GetThingDetails extends \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\Endpoint
+{
+    protected $thingId;
+    /**
+     * @param string $thingId
+     */
+    public function __construct(string $thingId)
+    {
+        $this->thingId = $thingId;
+    }
+    use \Jane\Component\OpenApi31\Tests\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{thingId}'], [$this->thingId], '/things/{thingId}/details');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['ApiKeyAuth'];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/ApiException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/BadRequestException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/BadRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+abstract class BadRequestException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/ClientException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/CreateThingBadRequestException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/CreateThingBadRequestException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+class CreateThingBadRequestException extends BadRequestException
+{
+    /**
+     * @var \Jane\Component\OpenApi31\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Invalid input');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi31\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/DeleteThingNotFoundException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/DeleteThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+class DeleteThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi31\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi31\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+class GetEndpointUnauthorizedException extends UnauthorizedException
+{
+    /**
+     * @var \Jane\Component\OpenApi31\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Unauthorized response');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi31\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/GetThingNotFoundException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/GetThingNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+class GetThingNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Jane\Component\OpenApi31\Tests\Client\Model\Error
+     */
+    private $error;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi31\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Thing not found');
+        $this->error = $error;
+        $this->response = $response;
+    }
+    public function getError(): \Jane\Component\OpenApi31\Tests\Client\Model\Error
+    {
+        return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/NotFoundException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+abstract class NotFoundException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/ServerException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/UnauthorizedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+abstract class UnauthorizedException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 401);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Exception/WithResponseInterface.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Exception/WithResponseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Exception;
+
+interface WithResponseInterface
+{
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface;
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Model/Error.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Model/Error.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Model;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class Error implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['message' => ['message', 'getMessage', 'setMessage']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Model/SimpleResponse.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Model/SimpleResponse.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Model;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class SimpleResponse implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $foo;
+    /**
+     * @var bool
+     */
+    protected $baz;
+    /**
+     * @return string
+     */
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+    /**
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo): self
+    {
+        $this->initialized['foo'] = true;
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * @return bool
+     */
+    public function getBaz(): bool
+    {
+        return $this->baz;
+    }
+    /**
+     * @param bool $baz
+     *
+     * @return self
+     */
+    public function setBaz(bool $baz): self
+    {
+        $this->initialized['baz'] = true;
+        $this->baz = $baz;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['foo' => ['foo', 'getFoo', 'setFoo'], 'baz' => ['baz', 'getBaz', 'setBaz']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Model/Thing.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Model/Thing.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Model;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class Thing implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['id' => ['id', 'getId', 'setId'], 'name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind'], 'createdAt' => ['createdAt', 'getCreatedAt', 'setCreatedAt'], 'tags' => ['tags', 'getTags', 'setTags']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Model/ThingDetails.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Model/ThingDetails.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Model;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class ThingDetails implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+    /**
+     * @var list<string>
+     */
+    protected $tags;
+    /**
+     * @var string
+     */
+    protected $description;
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return list<string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    /**
+     * @param list<string> $tags
+     *
+     * @return self
+     */
+    public function setTags(array $tags): self
+    {
+        $this->initialized['tags'] = true;
+        $this->tags = $tags;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+    /**
+     * @param string $description
+     *
+     * @return self
+     */
+    public function setDescription(string $description): self
+    {
+        $this->initialized['description'] = true;
+        $this->description = $description;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['id' => ['id', 'getId', 'setId'], 'name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind'], 'createdAt' => ['createdAt', 'getCreatedAt', 'setCreatedAt'], 'tags' => ['tags', 'getTags', 'setTags'], 'description' => ['description', 'getDescription', 'setDescription']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Model/ThingInput.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Model/ThingInput.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Model;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\AdditionalPropertiesInterface;
+class ThingInput implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var string
+     */
+    protected $kind;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+    /**
+     * @param string $kind
+     *
+     * @return self
+     */
+    public function setKind(string $kind): self
+    {
+        $this->initialized['kind'] = true;
+        $this->kind = $kind;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['name' => ['name', 'getName', 'setName'], 'kind' => ['kind', 'getKind', 'setKind']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/ErrorNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Client\Model\Error::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Client\Model\Error::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Client\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+            unset($data['message']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('message') && null !== $data->getMessage()) {
+            $dataArray['message'] = $data->getMessage();
+        }
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Client\Model\Error::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse::class => \Jane\Component\OpenApi31\Tests\Client\Normalizer\SimpleResponseNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Client\Model\Error::class => \Jane\Component\OpenApi31\Tests\Client\Normalizer\ErrorNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Client\Model\Thing::class => \Jane\Component\OpenApi31\Tests\Client\Normalizer\ThingNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput::class => \Jane\Component\OpenApi31\Tests\Client\Normalizer\ThingInputNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails::class => \Jane\Component\OpenApi31\Tests\Client\Normalizer\ThingDetailsNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('baz', $data) && \is_int($data['baz'])) {
+            $data['baz'] = (bool) $data['baz'];
+        }
+        if (\array_key_exists('foo', $data)) {
+            $object->setFoo($data['foo']);
+            unset($data['foo']);
+        }
+        if (\array_key_exists('baz', $data)) {
+            $object->setBaz($data['baz']);
+            unset($data['baz']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('foo') && null !== $data->getFoo()) {
+            $dataArray['foo'] = $data->getFoo();
+        }
+        if ($data->isInitialized('baz') && null !== $data->getBaz()) {
+            $dataArray['baz'] = $data->getBaz();
+        }
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Client\Model\SimpleResponse::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingDetailsNormalizer.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingDetailsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+            unset($data['createdAt']);
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+            unset($data['tags']);
+        }
+        if (\array_key_exists('description', $data)) {
+            $object->setDescription($data['description']);
+            unset($data['description']);
+        }
+        foreach ($data as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value_1;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        $dataArray['description'] = $data->getDescription();
+        foreach ($data->additionalPropertyEntries() as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value_1;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Client\Model\ThingDetails::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingInputNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingInputNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingInputNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Client\Model\ThingInput();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Client\Model\ThingInput::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Normalizer/ThingNormalizer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Client\Model\Thing::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Client\Model\Thing::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Client\Model\Thing();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('kind', $data)) {
+            $object->setKind($data['kind']);
+            unset($data['kind']);
+        }
+        if (\array_key_exists('createdAt', $data)) {
+            $date = \DateTime::createFromFormat('Y-m-d', $data['createdAt']);
+            if (false === $date) {
+                throw new \Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer\InvalidDateException($data['createdAt'], 'Y-m-d');
+            }
+            $object->setCreatedAt($date->setTime(0, 0, 0));
+            unset($data['createdAt']);
+        }
+        if (\array_key_exists('tags', $data)) {
+            $values = [];
+            foreach ($data['tags'] as $value) {
+                $values[] = $value;
+            }
+            $object->setTags($values);
+            unset($data['tags']);
+        }
+        foreach ($data as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value_1;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['name'] = $data->getName();
+        $dataArray['kind'] = $data->getKind();
+        $dataArray['createdAt'] = $data->getCreatedAt()->format('Y-m-d');
+        $values = [];
+        foreach ($data->getTags() as $value) {
+            $values[] = $value;
+        }
+        $dataArray['tags'] = $values;
+        foreach ($data->additionalPropertyEntries() as $key => $value_1) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value_1;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Client\Model\Thing::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$phpName};
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$phpName};
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/FormEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+/**
+ * Encodes and decodes application/x-www-form-urlencoded data.
+ *
+ * Encoding:   http_build_query($data)
+ * Decoding:   parse_str($data, $result) → array
+ *
+ * Note: PHP's parse_str() converts dots (.) in keys to underscores (_)
+ * and respects the max_input_vars ini setting.
+ */
+final class FormEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'form';
+    public function encode(mixed $data, string $format, array $context = []): string
+    {
+        return http_build_query($data);
+    }
+    public function decode(string $data, string $format, array $context = []): mixed
+    {
+        \parse_str($data, $result);
+        return $result;
+    }
+    public function supportsEncoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/client/generated/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Client\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/client/openapi.yaml
+++ b/src/Component/OpenApi31/Tests/client/openapi.yaml
@@ -7,7 +7,7 @@ info:
 servers:
   - url: http://127.0.0.1/
     variables:
-      port: { default: '4010' }
+      port: { default: '4012' }
 paths:
   /endpoint:
     get:
@@ -26,8 +26,114 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-security:
-  - ApiKeyAuth: []
+  /things:
+    post:
+      summary: Create a thing
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThingInput'
+      responses:
+        '201':
+          description: Thing created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /things/form:
+    post:
+      summary: Create a thing from form data
+      operationId: createFormThing
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ThingInput'
+      responses:
+        '200':
+          description: Thing created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+  /things/{thingId}:
+    get:
+      summary: Get a thing
+      operationId: getThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Thing found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '404':
+          description: Thing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete a thing
+      operationId: deleteThing
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Thing deleted
+        '404':
+          description: Thing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /things/{thingId}/details:
+    get:
+      summary: Get extended details of a thing
+      operationId: getThingDetails
+      parameters:
+        - name: thingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Extended thing details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingDetails'
 components:
   schemas:
     SimpleResponse:
@@ -42,8 +148,59 @@ components:
       properties:
         message:
           type: string
+    Thing:
+      type: object
+      required:
+        - id
+        - name
+        - kind
+        - createdAt
+        - tags
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        kind:
+          type: string
+          enum:
+            - created
+            - updated
+            - deleted
+        createdAt:
+          type: string
+          format: date
+        tags:
+          type: array
+          items:
+            type: string
+    ThingInput:
+      type: object
+      required:
+        - name
+        - kind
+      properties:
+        name:
+          type: string
+        kind:
+          type: string
+          enum:
+            - created
+            - updated
+            - deleted
+    ThingDetails:
+      allOf:
+        - $ref: '#/components/schemas/Thing'
+        - type: object
+          required:
+            - description
+          properties:
+            description:
+              type: string
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-API-Key
+security:
+  - ApiKeyAuth: []


### PR DESCRIPTION
## Description

Expands the prism-mocked functional tests so the fake OpenAPI API covers most of the generated client features for each component, and adds the missing functional test for OpenAPI 3.1. The existing `testClient()` tests only exercised a single GET endpoint with apiKey auth; the OpenAPI 3.1 component had the client scaffolding but no functional test at all.

## Changes

- Expanded the client specs (`src/Component/OpenApi3/Tests/client/openapi.yaml`, `src/Component/OpenApi31/Tests/client/openapi.yaml`, `src/Component/OpenApi2/Tests/client/swagger.yaml`) with new endpoints covering: path + required/optional query parameters, JSON request body, `application/x-www-form-urlencoded` request body (model-based on 3.x, formData array on 2.0), `allOf` merged model, `204` delete, and `400`/`404` error responses. Models cover enums, `format: date`, and arrays.
- Moved the OpenAPI 3.1 mock server to port 4012 (it was sharing 4010 with the OpenAPI 3.0 spec).
- Added `testClient()` to `src/Component/OpenApi31/Tests/JaneOpenApiResourceTest.php` and extended the OpenAPI 2/3 versions: unauthorized flow (now fails the test if no exception is thrown), authenticated call, `executeRawEndpoint()` raw PSR-7 response, and typed per-status exceptions (`GetThingNotFoundException`) selected via prism's `Prefer: code=404` header.
- Regenerated the committed client snapshots under `Tests/client/generated` for the three components (they are refreshed by the test at runtime anyway).
- `composer.json`: added the missing `Jane\Component\OpenApi31\Tests\Client\` autoload-dev mapping (required for the generated client to autoload).
- CI: run a third prism server on port 4012 in both `tests` and `tests-lowest` jobs; `docs/contributing/tests.md` updated accordingly (including fixing outdated `src/` paths in the documented commands).

## How to test

1. Start the three mock servers:
   ```bash
   nohup prism mock -p 4010 -m src/Component/OpenApi3/Tests/client/openapi.yaml &
   nohup prism mock -p 4011 -m src/Component/OpenApi2/Tests/client/swagger.yaml &
   nohup prism mock -p 4012 -m src/Component/OpenApi31/Tests/client/openapi.yaml &
   ```
2. Run the functional tests:
   ```bash
   vendor/bin/phpunit --testsuite OpenApi31 --filter testClient --exclude-group none
   vendor/bin/phpunit --testsuite OpenApi3 --filter testClient --exclude-group none
   vendor/bin/phpunit --testsuite OpenApi2 --filter testClient --exclude-group none
   ```
3. Or run everything: `vendor/bin/phpunit --exclude-group none`

## Notes

- Verified that prism supports the OpenAPI 3.1 document (security enforcement, dynamic response generation, `Prefer: code=` selection).
- No test fixtures were touched; the committed `Tests/client/generated` trees are runtime snapshots that the tests regenerate before asserting.
- Multipart request bodies are intentionally not covered through prism (prone to prism-side validation quirks); wire-level multipart behavior remains covered by the dedicated capturing-client functional tests.
