### PR TITLE
fix(json-schema): generate ValidationException whenever ValidatorTrait is required

### DIFF
--- a/src/Component/JsonSchema/Generator/RuntimeGenerator.php
+++ b/src/Component/JsonSchema/Generator/RuntimeGenerator.php
@@ -13,14 +13,19 @@ class RuntimeGenerator implements GeneratorInterface
     public const FILE_TYPE_RUNTIME = 'runtime';
 
     /**
-     * @var array<string, array{class: string, namespace: string[], source: string, file: string}>
+     * `requires` lists builders a runtime class depends on from inside its own
+     * template, invisible to require-sites: ValidatorTrait throws
+     * ValidationException, so emitting the trait without the exception makes
+     * generated clients fatal instead of throwing it.
+     *
+     * @var array<string, array{class: string, namespace: string[], source: string, file: string, requires?: string[]}>
      */
     private const BUILDERS = [
         'AdditionalAndPatternProperties' => ['class' => 'AdditionalAndPatternProperties', 'namespace' => [], 'source' => 'AdditionalAndPatternProperties.php', 'file' => 'AdditionalAndPatternProperties.php'],
         'AdditionalPropertiesInterface' => ['class' => 'AdditionalPropertiesInterface', 'namespace' => [], 'source' => 'AdditionalPropertiesInterface.php', 'file' => 'AdditionalPropertiesInterface.php'],
         'JsonObject' => ['class' => 'JsonObject', 'namespace' => [], 'source' => 'JsonObject.php', 'file' => 'JsonObject.php'],
         'CheckArray' => ['class' => 'CheckArray', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/CheckArray.php', 'file' => 'CheckArray.php'],
-        'ValidatorTrait' => ['class' => 'ValidatorTrait', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/ValidatorTrait.php', 'file' => 'ValidatorTrait.php'],
+        'ValidatorTrait' => ['class' => 'ValidatorTrait', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/ValidatorTrait.php', 'file' => 'ValidatorTrait.php', 'requires' => ['ValidationException']],
         'ReferenceNormalizer' => ['class' => 'ReferenceNormalizer', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/ReferenceNormalizer.php', 'file' => 'ReferenceNormalizer.php'],
         'InvalidDateException' => ['class' => 'InvalidDateException', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/InvalidDateException.php', 'file' => 'InvalidDateException.php'],
         'ValidationException' => ['class' => 'ValidationException', 'namespace' => ['Normalizer'], 'source' => 'Normalizer/ValidationException.php', 'file' => 'ValidationException.php'],
@@ -34,7 +39,10 @@ class RuntimeGenerator implements GeneratorInterface
 
     public function generate(Schema $schema, string $className, Context $context): void
     {
-        foreach ($this->getBuilders() as $config) {
+        $builders = $this->getBuilders();
+        $this->requireDependencies($schema, $builders);
+
+        foreach ($builders as $config) {
             $fqcn = $this->naming->getRuntimeClassFQCN($schema->getNamespace(), $config['namespace'], $config['class']);
             if ($schema->isRuntimeFileRequired($fqcn)) {
                 $sourceDir = $this->getSourceDir($config['namespace']);
@@ -53,6 +61,40 @@ class RuntimeGenerator implements GeneratorInterface
     protected function getBuilders(): array
     {
         return self::BUILDERS;
+    }
+
+    /**
+     * Marks the declared dependencies of every required runtime class as
+     * required themselves, so require-sites only have to know the class they
+     * use directly.
+     *
+     * @param array<string, array{class: string, namespace: string[], source: string, file: string, requires?: string[]}> $builders
+     */
+    private function requireDependencies(Schema $schema, array $builders): void
+    {
+        do {
+            $changed = false;
+
+            foreach ($builders as $config) {
+                if (!isset($config['requires'])) {
+                    continue;
+                }
+
+                if (!$schema->isRuntimeFileRequired($this->naming->getRuntimeClassFQCN($schema->getNamespace(), $config['namespace'], $config['class']))) {
+                    continue;
+                }
+
+                foreach ($config['requires'] as $dependency) {
+                    $dependencyConfig = $builders[$dependency];
+                    $dependencyFqcn = $this->naming->getRuntimeClassFQCN($schema->getNamespace(), $dependencyConfig['namespace'], $dependencyConfig['class']);
+
+                    if (!$schema->isRuntimeFileRequired($dependencyFqcn)) {
+                        $schema->addRequiredRuntimeFile($dependencyFqcn);
+                        $changed = true;
+                    }
+                }
+            }
+        } while ($changed);
     }
 
     /**

--- a/src/Component/JsonSchema/Tests/RuntimeGeneratorTest.php
+++ b/src/Component/JsonSchema/Tests/RuntimeGeneratorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Generator\File;
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Generator\RuntimeGenerator;
+use Jane\Component\JsonSchema\Registry\Registry;
+use Jane\Component\JsonSchema\Registry\Schema;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+class RuntimeGeneratorTest extends TestCase
+{
+    /**
+     * ValidatorTrait's own template throws ValidationException, a dependency
+     * require-sites cannot see: emitting the trait without the exception makes
+     * generated clients fatal with "Class not found" instead of throwing it.
+     *
+     * @see https://github.com/janephp/janephp/issues/1058
+     */
+    public function testRequiringValidatorTraitAlsoGeneratesItsValidationException(): void
+    {
+        $schema = new Schema('schema.json', 'Vendor\Api', '/tmp/generated', 'Client');
+        $schema->addRequiredRuntimeFile('Vendor\Api\Runtime\Normalizer\ValidatorTrait');
+
+        $generator = new RuntimeGenerator(new Naming(), (new ParserFactory())->createForHostVersion());
+        $generator->generate($schema, 'Client', new Context(new Registry()));
+
+        $files = array_map(static fn (File $file): string => basename($file->getFilename()), $schema->getFiles());
+
+        $this->assertContains('ValidatorTrait.php', $files);
+        $this->assertContains('ValidationException.php', $files);
+    }
+
+    public function testUnrequiredRuntimeClassesStayAbsent(): void
+    {
+        $schema = new Schema('schema.json', 'Vendor\Api', '/tmp/generated', 'Client');
+        $schema->addRequiredRuntimeFile('Vendor\Api\Runtime\Normalizer\CheckArray');
+
+        $generator = new RuntimeGenerator(new Naming(), (new ParserFactory())->createForHostVersion());
+        $generator->generate($schema, 'Client', new Context(new Registry()));
+
+        $files = array_map(static fn (File $file): string => basename($file->getFilename()), $schema->getFiles());
+
+        $this->assertSame(['CheckArray.php'], $files);
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/JsonSchema/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\RuntimeBoilerplate\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}


### PR DESCRIPTION
Fixes #1058: since the only-generate-when-required runtime emission (#1049, unreleased), `createJaneObjectNormalizerClass()` registers `ValidatorTrait` without `ValidationException` — the class the trait's own template throws. Clients whose only requirement comes from that path (endpoint-heavy OpenAPI specs without validated models — 36 of the repository's own fixtures) ship a trait whose `validate()` fatals with `Error: Class "…\Runtime\Normalizer\ValidationException" not found` instead of throwing the catchable exception (full reproduction in #1058).

## What

- `RuntimeGenerator::BUILDERS` entries can now declare template-internal dependencies (`requires`), resolved to required files before emission — direction 2 from the issue, so require-sites only need to know the class they use directly and this bug class cannot recur for other templates.
- `ValidatorTrait` declares `requires: [ValidationException]`.
- New `RuntimeGeneratorTest` locks the invariant in (the fixture comparison skips `Runtime/` paths by design, so it cannot).
- The four `runtime-boilerplate` trees gain the previously missing `ValidationException.php` (they are full-compare, so the template's content is now asserted centrally again). Every other affected fixture still carried its pre-#1049 copy, which this change makes **correct again** rather than stale — no other tree changes.

Verified against the #1058 reproduction: the regenerated dummy client now contains `Runtime/Normalizer/ValidationException.php`, and triggering a validation failure throws `ValidationException: Model validation failed with 1 errors` instead of the fatal.

Not bundled (follow-up candidates from the issue): dropping the unconditional `ValidatorTrait` requirement in `JaneObjectNormalizer` when nothing calls `validate()`.

## Validation

- New `RuntimeGeneratorTest` — green (and red on the unfixed generator)
- Full suite — OK (the only local failure is `ReferenceTest`'s `/var/tmp` symlink quirk on macOS, present on `next` unchanged)
- `castor qa:cs:check` and PHPStan over `src/` — clean

Prepared with an AI agent (Claude Code); I use Jane-generated clients in a production codebase; all changes verified by running the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
