### PR TITLE
fix(json-schema): guard nested collection loops against null entries

### DIFF
--- a/src/Component/JsonSchema/Guesser/Guess/ArrayType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/ArrayType.php
@@ -11,6 +11,8 @@ use PhpParser\Node\Stmt;
 
 class ArrayType extends Type
 {
+    use CheckNullableTrait;
+
     protected Type $itemType;
 
     public function __construct(object $object, Type $itemType, string $type = 'array')
@@ -53,7 +55,7 @@ class ArrayType extends Type
 
         list($subStatements, $outputExpr) = $this->itemType->createDenormalizationStatement($context, $loopValueVar, $normalizerFromObject);
 
-        $loopStatements = array_merge($subStatements, [
+        $loopStatements = array_merge($this->createNullableItemGuardStatements($valuesVar, $loopKeyVar, $loopValueVar), $subStatements, [
             new Stmt\Expression(new Expr\Assign($this->createLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr)),
         ]);
 
@@ -88,7 +90,7 @@ class ArrayType extends Type
 
         list($subStatements, $outputExpr) = $this->itemType->createNormalizationStatement($context, $loopValueVar, $normalizerFromObject);
 
-        $loopStatements = array_merge($subStatements, [
+        $loopStatements = array_merge($this->createNullableItemGuardStatements($valuesVar, $loopKeyVar, $loopValueVar), $subStatements, [
             new Stmt\Expression(new Expr\Assign($this->createNormalizationLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr)),
         ]);
 
@@ -128,5 +130,29 @@ class ArrayType extends Type
     protected function createNormalizationLoopOutputAssignement(Expr $valuesVar, $loopKeyVar): Expr
     {
         return new Expr\ArrayDimFetch($valuesVar);
+    }
+
+    private function createNullableItemGuardStatements(Expr $valuesVar, $loopKeyVar, Expr $loopValueVar): array
+    {
+        if (!$this->itemType instanceof self
+            || null === $this->itemType->getObject()
+            || !$this->isNullable($this->itemType->getObject())) {
+            return [];
+        }
+
+        return [
+            new Stmt\If_(
+                new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), $loopValueVar),
+                [
+                    'stmts' => [
+                        new Stmt\Expression(new Expr\Assign(
+                            $this->createLoopOutputAssignement($valuesVar, $loopKeyVar),
+                            new Expr\ConstFetch(new Name('null'))
+                        )),
+                        new Stmt\Continue_(),
+                    ],
+                ]
+            ),
+        ];
     }
 }

--- a/src/Component/OpenApi2/Tests/NullableMapEntryNormalizationTest.php
+++ b/src/Component/OpenApi2/Tests/NullableMapEntryNormalizationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests;
+
+use Docker\Api\Model\NetworkSettings;
+use Docker\Api\Model\PortBinding;
+use Docker\Api\Normalizer\JaneObjectNormalizer;
+use Docker\Api\Runtime\JsonObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Regression tests for GH#559: null entries inside a map of nullable arrays
+ * must not crash the normalizer ("foreach() argument must be of type
+ * array|object, null given") and must round-trip as null.
+ */
+class NullableMapEntryNormalizationTest extends TestCase
+{
+    public function testDenormalizeMapWithNullEntry(): void
+    {
+        $settings = $this->createSerializer()->denormalize([
+            'Ports' => [
+                '9000/tcp' => null,
+                '80/tcp' => [
+                    ['HostIp' => '0.0.0.0', 'HostPort' => '80'],
+                ],
+            ],
+        ], NetworkSettings::class, 'json');
+
+        self::assertNull($settings->getPorts()['9000/tcp']);
+
+        $bindings = $settings->getPorts()['80/tcp'];
+        self::assertIsArray($bindings);
+        self::assertInstanceOf(PortBinding::class, $bindings[0]);
+    }
+
+    public function testNormalizeModelWithNullMapEntry(): void
+    {
+        $bindings = new JsonObject();
+        $bindings[] = (new PortBinding())->setHostIp('0.0.0.0')->setHostPort('80');
+
+        $ports = new JsonObject();
+        $ports['9000/tcp'] = null;
+        $ports['80/tcp'] = $bindings;
+
+        $settings = new NetworkSettings();
+        $settings->setPorts($ports);
+
+        $data = json_encode($this->createSerializer()->normalize($settings, 'json'));
+
+        self::assertStringContainsString('"9000\/tcp":null', $data);
+    }
+
+    private function createSerializer(): Serializer
+    {
+        return new Serializer([new JaneObjectNormalizer()], [new JsonEncoder()]);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/HostConfigNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/HostConfigNormalizer.php
@@ -215,6 +215,10 @@ class HostConfigNormalizer implements DenormalizerInterface, NormalizerInterface
         if (\array_key_exists('PortBindings', $data)) {
             $values_10 = new \Docker\Api\Runtime\JsonObject();
             foreach ($data['PortBindings'] as $key => $value_10) {
+                if (null === $value_10) {
+                    $values_10[$key] = null;
+                    continue;
+                }
                 $values_11 = [];
                 foreach ($value_10 as $value_11) {
                     $values_11[] = $this->denormalizer->denormalize($value_11, \Docker\Api\Model\PortBinding::class, 'json', $context);
@@ -546,6 +550,10 @@ class HostConfigNormalizer implements DenormalizerInterface, NormalizerInterface
         if ($data->isInitialized('portBindings') && null !== $data->getPortBindings()) {
             $values_10 = new \Docker\Api\Runtime\JsonObject();
             foreach ($data->getPortBindings() as $key => $value_10) {
+                if (null === $value_10) {
+                    $values_10[$key] = null;
+                    continue;
+                }
                 $values_11 = [];
                 foreach ($value_10 as $value_11) {
                     $values_11[] = $value_11 === null ? null : new \Docker\Api\Runtime\JsonObject($this->normalizer->normalize($value_11, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/NetworkSettingsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/NetworkSettingsNormalizer.php
@@ -61,6 +61,10 @@ class NetworkSettingsNormalizer implements DenormalizerInterface, NormalizerInte
         if (\array_key_exists('Ports', $data)) {
             $values = new \Docker\Api\Runtime\JsonObject();
             foreach ($data['Ports'] as $key => $value) {
+                if (null === $value) {
+                    $values[$key] = null;
+                    continue;
+                }
                 $values_1 = [];
                 foreach ($value as $value_1) {
                     $values_1[] = $this->denormalizer->denormalize($value_1, \Docker\Api\Model\PortBinding::class, 'json', $context);
@@ -146,6 +150,10 @@ class NetworkSettingsNormalizer implements DenormalizerInterface, NormalizerInte
         if ($data->isInitialized('ports') && null !== $data->getPorts()) {
             $values = new \Docker\Api\Runtime\JsonObject();
             foreach ($data->getPorts() as $key => $value) {
+                if (null === $value) {
+                    $values[$key] = null;
+                    continue;
+                }
                 $values_1 = [];
                 foreach ($value as $value_1) {
                     $values_1[] = $value_1 === null ? null : new \Docker\Api\Runtime\JsonObject($this->normalizer->normalize($value_1, 'json', $context));


### PR DESCRIPTION
## Description

Fixes GH#559: when a schema declares a map (`type: object` + `additionalProperties`) or an array whose values are **nullable collections** (`x-nullable: true` in OpenAPI 2, `nullable: true` in OpenAPI 3, or a type array containing `null` in JSON Schema), the generated normalizers produced a nested `foreach ($value as ...)` loop without any null check. A valid payload such as a Docker `PortMap` containing `"9000/tcp": null` then crashed with `foreach() argument must be of type array|object, null given`.

The property-level guard added for #201 only covers the whole-property-null case; here the nullability lives on the nested `additionalProperties` schema, so the crash happened on individual map entries.

## Changes

- `ArrayType` (inherited by `MapType`) now prepends a null guard to generated collection loops on both denormalization and normalization when the **item type** is itself a nullable collection type: generated code assigns `null` for such entries and `continue`s, preserving null on round-trip (consistent with the existing null-ternary used for nullable object items in normalization).
- Guards are only generated when the item schema declares nullability (`x-nullable` / `nullable` / type containing `null`), so generated output for all other schemas is unchanged.
- `docker-api` fixture normalizers regenerated (`NetworkSettingsNormalizer`, `HostConfigNormalizer`: +2 guards each, one per direction).
- New regression test `NullableMapEntryNormalizationTest` (OpenApi2) covering denormalization and normalization of a map with a null entry; verified to reproduce the GH#559 crash without the fix.

## How to test

1. `vendor/bin/phpunit --testsuite OpenApi2 --filter NullableMapEntryNormalizationTest`
2. Full suites: `vendor/bin/phpunit --testsuite OpenApi2` (also run `OpenApi3`, `OpenApi31`, `JsonSchema`) — all green.
3. `castor qa:phpstan` — no errors.

## Notes

- No breaking change: generated code changes only for schemas with nullable nested collections (the fixtures diff shows +8 lines per affected normalizer).
- `MultipleType` and `PatternMultipleType` items need no guard: their generated branches are already `is_array(...)`-condition protected, so a null entry simply skips every branch.
