### PR TITLE
fix(open-api): stream a single response, always generate the Endpoint interface, type Client::create() (#1066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [OpenApi2] [OpenApi3] [OpenApi31] Generated endpoint constructors and client methods now document their `$queryParameters` / `$headerParameters` / `$formParameters` arrays with a PHPDoc array shape that parses: OpenAPI 2 output used the phpDocumentor 2 `@param array $queryParameters { @var int $keep-storage ... }` inline-tag form, and multi-line parameter descriptions in OpenAPI 3 / 3.1 output continued outside the `//` comment. Either one makes PHPStan, Mago and IDEs drop the whole docblock (`@throws` and `@return` included). All three components now share one emitter: `@param array{ "keep-storage"?: int, //description ... } $queryParameters`, with every further description line on its own `//` line
+- [OpenApi] The runtime `Client::stream()` now streams a single `ResponseInterface` argument instead of iterating over it as an object, which streamed nothing
+- [OpenApi] A specification without operations no longer generates a runtime `Client` referencing an `Endpoint` interface that is never generated: the Client template declares the dependency
+- [OpenApi] Generated clients are cleaner for static analysers: `Client::create()` documents `$additionalPlugins` as `list<callable(HttpClientInterface): HttpClientInterface>` and `$additionalNormalizers` as normalizer instances, and the runtime `FormEncoder` initialises the `parse_str()` output variable (the runtime-template family of the Mago baseline, #1066)
 
 ## [7.14.0] - 2026-08-31
 ### Added

--- a/mago-generated-baseline.toml
+++ b/mago-generated-baseline.toml
@@ -1046,12 +1046,6 @@ count = 1
 
 [[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\AllBooleanQueryResolver\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
 count = 1
@@ -1066,24 +1060,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -1117,54 +1093,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi2\Tests\Expected\AllOfMerge\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi2\Tests\Expected\AllOfMerge\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\ArrayDefinition\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -1195,24 +1123,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKeyHeader\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -1237,24 +1147,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKeyQuery\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -1276,24 +1168,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -1357,24 +1231,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\BooleanQueryResolver\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -1390,24 +1246,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/content-type/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -1465,18 +1303,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/CustomEndpointGenerator.php"
 code = "non-existent-class-like"
 message = 'Class `Jane\Component\OpenApi2\Tests\Fixtures\CustomEndpointGenerator\CustomEndpointGenerator` cannot extend unknown type `EndpointGenerator`'
@@ -1492,12 +1318,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/CustomEndpointTrait.php"
 code = "non-existent-class-like"
 message = 'Class, interface, enum, or trait `Jane\Component\OpenApi2\Tests\Fixtures\CustomEndpointGenerator\Client` not found.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -1519,24 +1339,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Discriminator\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -1553,54 +1355,6 @@ file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Normalizer/
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi2\Tests\Expected\Discriminator\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi2\Tests\Expected\Discriminator\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php"
@@ -4885,24 +4639,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\EnumAsObjects\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -4918,24 +4654,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -4963,24 +4681,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Two\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -5002,24 +4702,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/TestTwoGetResponse200Normalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -5047,24 +4729,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\FromUrl\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -5083,24 +4747,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Host\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -5116,24 +4762,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/host/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30145,24 +29773,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 3
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Issue831\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -30193,24 +29803,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Issue832\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -30232,24 +29824,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30367,24 +29941,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\MultiResources\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -30406,24 +29962,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30451,24 +29989,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Api2\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -30484,24 +30004,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30571,24 +30073,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\NoReferenceResponse\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -30610,24 +30094,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30658,54 +30124,6 @@ count = 5
 file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi2\Tests\Expected\NullableCheck\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi2\Tests\Expected\NullableCheck\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/operations/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -30835,24 +30253,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php"
 code = "invalid-parameter-default-value"
 message = "Default value for parameter `$formParameters` is not assignable to its declared type."
@@ -30955,24 +30355,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\ResponseReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31000,24 +30382,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31051,24 +30415,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\ThrowUnexpectedStatusCode\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31078,24 +30424,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31114,24 +30442,6 @@ count = 1
 file = "src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31174,54 +30484,6 @@ count = 10
 file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi2\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi2\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31300,24 +30562,6 @@ count = 2
 file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/ProjectsNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31405,24 +30649,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 15
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\XNamespace\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31471,24 +30697,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi2\Tests\Expected\Yaml\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31507,24 +30715,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\AllBooleanQueryResolver\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31540,24 +30730,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31588,54 +30760,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\AllOfMerge\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\AllOfMerge\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -31697,24 +30821,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php"
@@ -31855,54 +30961,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\AllOfSchemaWithOneOfProperty\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\AllOfSchemaWithOneOfProperty\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\AnyOfDiscriminator\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -31993,24 +31051,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\AnyOfMixedRequestBodyParameterType\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32032,24 +31072,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32125,24 +31147,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ApplicationProblemJsonResponse\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32165,24 +31169,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php"
@@ -32215,24 +31201,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32248,54 +31216,6 @@ count = 5
 file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32323,24 +31243,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\AuthenticationApiKeyQuery\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32362,24 +31264,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32407,24 +31291,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\AuthenticationHttpBearer\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32446,24 +31312,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32497,24 +31345,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\BadResponse\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32524,24 +31354,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32605,24 +31417,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\BooleanQueryResolver\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32638,24 +31432,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/content-type/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32713,18 +31489,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/CustomEndpointGenerator.php"
 code = "non-existent-class-like"
 message = 'Class `Jane\Component\OpenApi3\Tests\Fixtures\CustomEndpointGenerator\CustomEndpointGenerator` cannot extend unknown type `EndpointGenerator`'
@@ -32740,12 +31504,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/CustomEndpointTrait.php"
 code = "non-existent-class-like"
 message = 'Class, interface, enum, or trait `Jane\Component\OpenApi3\Tests\Fixtures\CustomEndpointGenerator\Client` not found.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32767,24 +31525,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\CustomStringFormatMapping\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32800,24 +31540,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -32851,54 +31573,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\DefaultAdditionalProps\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\DefaultAdditionalProps\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Deprecated\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32923,54 +31597,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\Deprecated\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\Deprecated\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -32987,54 +31613,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php"
@@ -33055,54 +31633,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\Discriminator\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\Discriminator\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\EnumAsObjects\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33118,24 +31648,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33157,24 +31669,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Two\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33190,24 +31684,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33232,24 +31708,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Normalizer/MessageNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33301,24 +31759,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\FetchModeEager\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33349,24 +31789,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\FetchModeHead\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33382,24 +31804,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33424,24 +31828,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Normalizer/PetsGetResponse200Normalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33499,24 +31885,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\GenerateErrorExceptions\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33547,24 +31915,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\HostWithPortAndBasePath\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33574,24 +31924,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33607,24 +31939,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Host\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33634,24 +31948,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/host/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -33703,54 +31999,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\IncludeNullValue\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\IncludeNullValue\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWithMapping\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -33767,54 +32015,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-wi
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWithMapping\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWithMapping\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php"
@@ -33859,24 +32059,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php"
 code = "invalid-parameter-default-value"
 message = "Default value for parameter `$queryParameters` is not assignable to its declared type."
@@ -33904,24 +32086,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -36883,24 +35047,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 10
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Gounlaf\JanephpBug\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -36934,24 +35080,6 @@ count = 2
 file = "src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Normalizer/PatchableEntityNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -57607,24 +55735,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue641\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -57649,54 +55759,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\Issue641\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\Issue641\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue649\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -57706,24 +55768,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -76285,24 +74329,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue670\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76423,24 +74449,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue672\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76531,24 +74539,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue675\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76564,24 +74554,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -76621,24 +74593,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue737\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76675,24 +74629,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue787\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76714,24 +74650,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -76789,24 +74707,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Issue803\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76834,24 +74734,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -76903,24 +74785,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Issue823\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -76942,24 +74806,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -76990,24 +74836,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77101,24 +74929,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -77135,54 +74945,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Norm
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php"
@@ -77206,24 +74968,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77251,24 +74995,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Api2\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -77284,24 +75010,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77338,24 +75046,6 @@ count = 2
 file = "src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77413,24 +75103,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\NoOperationIdWithDotPath\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -77452,24 +75124,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/MessageM700PostBodyNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77527,24 +75181,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\NoReferenceResponse\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -77566,24 +75202,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/operations/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77713,24 +75331,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php"
 code = "invalid-parameter-default-value"
 message = "Default value for parameter `$queryParameters` is not assignable to its declared type."
@@ -77752,24 +75352,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77800,24 +75382,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -77965,24 +75529,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 5
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -77998,54 +75544,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Normalizer/ModelNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -78103,24 +75601,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ResponseReferenceWithSchemaReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78157,24 +75637,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ResponseReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78205,24 +75667,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ResponseTypeReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78244,24 +75688,6 @@ count = 2
 file = "src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -78325,24 +75751,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\SimplePathArrayParameter\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78352,24 +75760,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -78409,24 +75799,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 3
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php"
 code = "invalid-parameter-default-value"
 message = "Default value for parameter `$headerParameters` is not assignable to its declared type."
@@ -78463,24 +75835,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\StatusCodeRange\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78496,24 +75850,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -78553,24 +75889,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\TestNullable\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78607,24 +75925,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 3
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\ThrowUnexceptedStatusCode\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78643,24 +75943,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\UppercaseParameter\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -78676,24 +75958,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -78739,54 +76003,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi3\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi3\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php"
 code = "invalid-parameter-default-value"
 message = "Default value for parameter `$headerParameters` is not assignable to its declared type."
@@ -78827,24 +76043,6 @@ file = "src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Normalizer/
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 2
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php"
@@ -79309,24 +76507,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 4
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsCircularReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -79405,24 +76585,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsReferenceWithoutContent\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -79447,24 +76609,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsRequestBodyReference\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -79486,24 +76630,6 @@ count = 1
 file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -79969,24 +77095,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 4
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\XNamespace\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80035,24 +77143,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi3\Tests\Expected\Yaml\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80071,24 +77161,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80104,54 +77176,6 @@ count = 5
 file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80177,24 +77201,6 @@ file = "src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Normal
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 4
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Client.php"
@@ -80224,54 +77230,6 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Normalizer/UnspecifiedNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi31\Tests\DefaultAdditionalProps\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi31\Tests\DefaultAdditionalProps\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80335,54 +77293,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-destructuring-source"
-message = "Invalid destructuring assignment: Cannot unpack type `mixed` into variables."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client\Endpoint)`).'
-count = 12
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client\Endpoint`.'
-count = 3
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-iterator-type"
-message = "Cannot determine the type of the expression provided to `foreach`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php"
-code = "unknown-match-subject-type"
-message = "The type of the match subject expression is unknown."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\EnumAsObjects\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80398,24 +77308,6 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80446,24 +77338,6 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Normalizer/UserNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80506,24 +77380,6 @@ count = 5
 file = "src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Normalizer/WidgetSettingsNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80593,24 +77449,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80653,24 +77491,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\Issue869\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80705,24 +77525,6 @@ file = "src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Normalizer/Mes
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 6
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php"
@@ -80788,24 +77590,6 @@ count = 6
 file = "src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Normalizer/UserNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -80875,24 +77659,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\Issue946\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80935,24 +77701,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\Issue963\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -80986,24 +77734,6 @@ count = 7
 file = "src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Normalizer/RequestErrorNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -81052,24 +77782,6 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderProductNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -81137,24 +77849,6 @@ file = "src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/Rep
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
 count = 5
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
 
 [[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php"
@@ -81265,24 +77959,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 2
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\NullableAllofInOneof\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -81355,24 +78031,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\NullableDate\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -81409,18 +78067,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Validator/EventConstraint.php"
 code = "invalid-argument"
 message = 'Invalid argument type for argument #1 of `Symfony\Component\Validator\Constraints\NotBlank::__construct`: expected `bool|null`, but found `int(1)`.'
@@ -81430,12 +78076,6 @@ count = 2
 file = "src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Authentication/ApiKeyCookieAuthentication.php"
 code = "write-only-property"
 message = "Property `$apiKey` is written to but never read."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -81775,24 +78415,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\Simple\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -81847,24 +78469,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 5
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\StatusCodeRange\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -81880,24 +78484,6 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
 count = 1
 
 [[issues]]
@@ -82273,24 +78859,6 @@ message = "Redundant null coalesce: left-hand side can never be `null` or undefi
 count = 1
 
 [[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 1
-
-[[issues]]
 file = "src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new static()`: constructor of `Jane\Component\OpenApi31\Tests\Expected\XNamespace\Client` is not final and its signature might change in child classes, potentially leading to runtime errors.'
@@ -82336,16 +78904,4 @@ count = 1
 file = "src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php"
-code = "non-iterable-object-iteration"
-message = 'Iterating over object of type `Symfony\Contracts\HttpClient\ResponseInterface` which does not implement `Iterator` or `IteratorAggregate`.'
-count = 1
-
-[[issues]]
-file = "src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php"
-code = "reference-to-undefined-variable"
-message = "Reference created from a previously undefined variable `$result`."
 count = 1

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\AllBooleanQueryReso
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\AllBooleanQueryResolver\Endpoint\GetFoo($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi2\Tests\Expected\AllOfMerge;
 
 class Client extends \Jane\Component\OpenApi2\Tests\Expected\AllOfMerge\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\AllOfMerge\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\ArrayDefinition\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\ArrayDefinition\Endpoint\TestSimple());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKe
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKeyHeader\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKe
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\AuthenticationApiKeyQuery\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
@@ -31,6 +31,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\BodyParameter\Runti
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\BodyParameter\Endpoint\TestObjectListBodyParameter($testObjectList));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\BooleanQueryResolve
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\BooleanQueryResolver\Endpoint\GetFoo($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Client.php
@@ -21,6 +21,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\ContentType\Runtime
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\ContentType\Endpoint\ProducesTriggersAcceptBeingSet());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\CustomEndpointGener
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\CustomEndpointGenerator\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Discriminator;
 
 class Client extends \Jane\Component\OpenApi2\Tests\Expected\Discriminator\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Discriminator\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
@@ -2046,6 +2046,10 @@ class Client extends \Docker\Api\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Docker\Api\Endpoint\Session());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\EnumAsObjects\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\EnumAsObjects\Endpoint\GetItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\One\Endpoint\TestOne());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Two\Endpoint\TestTwo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
@@ -16,6 +16,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Exceptions\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Exceptions\Endpoint\TestNoTag());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
@@ -32,6 +32,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\FromUrl\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\FromUrl\Endpoint\ShowPetById($petId));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Host\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Host\Endpoint\TestHost());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
@@ -17637,6 +17637,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue770\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue770\Endpoint\UpdateSystemIpsec($body, $queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Client.php
@@ -29,6 +29,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Issue831\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Issue831\Endpoint\_Print());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Issue832\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Issue832\Endpoint\PrefixStatuscheck());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-832/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
@@ -49,6 +49,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\ModelInResponse\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\ModelInResponse\Endpoint\GetTestComplexList());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\MultiResources\Runt
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\MultiResources\Endpoint\ProducesTriggersAcceptBeingSet());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Api1\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Api2\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\NoReferenceBody\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\NoReferenceBody\Endpoint\Test($body));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\NoReferenceResponse
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\NoReferenceResponse\Endpoint\Test());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi2\Tests\Expected\NullableCheck;
 
 class Client extends \Jane\Component\OpenApi2\Tests\Expected\NullableCheck\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\NullableCheck\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Client.php
@@ -132,6 +132,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Operations\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Operations\Endpoint\PostNo200Thing());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
@@ -122,6 +122,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Parameters\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Parameters\Endpoint\GetByTestInteger($testInteger));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\ResponseReference\R
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\ResponseReference\Endpoint\TestRefArray());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi2\Tests\RuntimeBoilerplate;
 
 class Client extends \Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\OpenApi2\Tests\Expected\SkipParameterCheck\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\SkipParameterCheck\Endpoint\TestGetWithPathParameters($testPath, $testBody, $queryParameters, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\ThrowUnexpectedStat
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\ThrowUnexpectedStatusCode\Endpoint\TestNoTag());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\UppercaseParameter\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\UppercaseParameter\Endpoint\TestGetWithUppercasePathParameters($testParameter));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi2\Tests\Expected\UseCacheableSupportsMethod;
 
 class Client extends \Jane\Component\OpenApi2\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -40,6 +40,10 @@ class Client extends \Jane\OpenApi2\Tests\Expected\WhitelistedPathsArrayNotation
     {
         return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\WhitelistedPathsArrayNotation\Endpoint\ListProjects($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -50,6 +50,10 @@ class Client extends \Jane\OpenApi2\Tests\Expected\WhitelistedPaths\Runtime\Clie
     {
         return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\WhitelistedPaths\Endpoint\CreateProject($payload));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
@@ -28,6 +28,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\XNamespace\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\XNamespace\Endpoint\Ops\Monitoring\GetTaggedItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Yaml\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Yaml\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AllBooleanQueryReso
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AllBooleanQueryResolver\Endpoint\GetFoo($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\AllOfMerge;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\AllOfMerge\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\AllOfMerge\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AllOfNullableRefere
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AllOfNullableReferenceProperty\Endpoint\GetBar());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\AllOfSchemaWithOneOfProperty;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\AllOfSchemaWithOneOfProperty\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\AllOfSchemaWithOneOfProperty\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-schema-with-one-of-property/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AnyOfDiscriminator\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AnyOfDiscriminator\Endpoint\TestAnyOfWithDiscriminator());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AnyOfMixedRequestBo
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AnyOfMixedRequestBodyParameterType\Endpoint\TestMixedRequestBody($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AnyOfNullableRefere
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AnyOfNullableReferenceProperty\Endpoint\GetUser());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected.manifest.json
@@ -2,7 +2,7 @@
     "algorithm": "sha256",
     "files": {
         "Authentication/ApiKeyAuthentication.php": "26e4d547cb8710d3a23c253b53fcb14df1db0c2a09533a5a334f90361055f8f5",
-        "Client.php": "bc0b5f8339f83ee349f3e1e44e32ef1f7eac99259b7d59ebdf00451ce11b0755",
+        "Client.php": "72ff75b50dc8d292215032684dca8a0e43d9599d73fe6335c73f964cf49d157d",
         "Endpoint/ApiBooksBookIdreviewsGetCollection.php": "4510cb5641bfca09f793e37b26a9e3773b95f5877477c68b91e7357c0c41fabc",
         "Endpoint/ApiBooksGetCollection.php": "5e46728cf08c404b11b72bcc0a47682997cddb91da4853af234bca766e427fa0",
         "Endpoint/ApiBooksIdDelete.php": "baa3560f7a2665033dee6db4d14aa32e45f027ed09bad4cb163b9d0fde709af9",

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
@@ -16,6 +16,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ApplicationProblemJ
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ApplicationProblemJsonResponse\Endpoint\PostFoo($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ArrayDefinition\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ArrayDefinition\Endpoint\TestSimple());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation;
 
 class Client extends \Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\ArrayItemsValidation\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AuthenticationApiKe
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AuthenticationApiKeyHeader\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AuthenticationApiKe
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AuthenticationApiKeyQuery\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AuthenticationHttpB
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AuthenticationHttpBasic\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AuthenticationHttpB
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AuthenticationHttpBearer\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
@@ -28,6 +28,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\AuthenticationMulti
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\AuthenticationMultipleSecurityLayers\Endpoint\GetBaz());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\BadResponse\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
@@ -31,6 +31,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\BodyParameter\Runti
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\BodyParameter\Endpoint\TestObjectListBodyParameter($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\BooleanQueryResolve
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\BooleanQueryResolver\Endpoint\GetFoo($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Client.php
@@ -21,6 +21,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ContentType\Runtime
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ContentType\Endpoint\ProducesTriggersAcceptBeingSet());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\CustomEndpointGener
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\CustomEndpointGenerator\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\CustomStringFormatM
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\CustomStringFormatMapping\Endpoint\GetSomething());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\DefaultAdditionalProps;
 
 class Client extends \Jane\Component\OpenApi3\Tests\DefaultAdditionalProps\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\DefaultAdditionalProps\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Deprecated;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\Deprecated\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Deprecated\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\DiscriminatorSnakeCase\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Discriminator;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\Discriminator\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Discriminator\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\EnumAsObjects\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\EnumAsObjects\Endpoint\GetItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\One\Endpoint\TestOne());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Two\Endpoint\TestTwo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Exceptions\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Exceptions\Endpoint\TestNoTag());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Client.php
@@ -30,6 +30,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\FetchModeDefault\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\FetchModeDefault\Endpoint\GetPet($petId));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-default/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\FetchModeEager\Runtime\Clien
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\FetchModeEager\Endpoint\GetPets());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-eager/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\FetchModeHead\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\FetchModeHead\Endpoint\HeadPets());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-head/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\FetchModePreload\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\FetchModePreload\Endpoint\GetPets());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/fetch-mode-preload/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
@@ -33,6 +33,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\FromUrl\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\FromUrl\Endpoint\ShowPetById($petId));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\GenerateErrorExcept
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\GenerateErrorExceptions\Endpoint\GetUser());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected.manifest.json
@@ -1,7 +1,7 @@
 {
     "algorithm": "sha256",
     "files": {
-        "Client.php": "5f4281cf3f929102d06a5c3d1ece4780d7d516fc6b55ccf05369ce5a2f1d841c",
+        "Client.php": "f208d016b96f4c61bcb76a55aac8fd801eafed13ef5fcfe3fd695cee77276edf",
         "Endpoint/ActionsAddSelectedRepoToOrgSecret.php": "5bda4fa43e31a056276fdfda7ce7b9665570ac79abaf252be06497d6e36b37d8",
         "Endpoint/ActionsCancelWorkflowRun.php": "8c5ef3707b22d9ea098c70b1df5da60267c81164e1e70503280aed0319f3f23d",
         "Endpoint/ActionsCreateOrUpdateOrgSecret.php": "f921f1019ac5677e27a36a2baf6add7e1f2bd719b8351afeef35f6d6ea11fe88",

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\HostWithPortAndBase
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\HostWithPortAndBasePath\Endpoint\TestHost());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\HostWithPort\Runtim
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\HostWithPort\Endpoint\TestHost());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Host\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Host\Endpoint\TestHost());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\IncludeNullValue;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\IncludeNullValue\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\IncludeNullValue\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWi
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWithMapping\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\InheritanceUsingDiscriminatorWithMapping\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedIssue1036\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\ExpectedIssue1036\Endpoint\UploadDocument($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
@@ -17,6 +17,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue299\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue299\Endpoint\GetUsers($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
@@ -1137,6 +1137,10 @@ class Client extends \CreditSafe\API\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \CreditSafe\API\Endpoint\CustomReportParameters($country, $queryParameters, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
@@ -16,6 +16,10 @@ class Client extends \Gounlaf\JanephpBug\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Gounlaf\JanephpBug\Endpoint\PatchEntity($id, $requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
@@ -3703,6 +3703,10 @@ class Client extends \PicturePark\API\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \PicturePark\API\Endpoint\XmpMappingDeleteMany($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Issue641;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue641\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Issue641\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue649\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue649\Endpoint\TestGetWithDefaultValuesInPathParameters($bar, $foo, $queryParameters, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
@@ -9772,6 +9772,10 @@ class Client extends \Jane\Generated\DigitalOcean\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\Generated\DigitalOcean\Endpoint\GenaiListEvaluationTestCasesByWorkspace($workspaceUuid));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Client.php
@@ -55,6 +55,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue670\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue670\Endpoint\PostEndpoint3($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue672\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue672\Endpoint\GetEndpoint3());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Client.php
@@ -17,6 +17,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue675\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue675\Endpoint\TestSimple($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Issue680\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Issue680\Endpoint\PostTest($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-680/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue737\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue737\Endpoint\PostFile($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Client.php
@@ -24,6 +24,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue787\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue787\Endpoint\PostFoo($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedIssue793\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\ExpectedIssue793\Endpoint\UploadFile($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-793/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue803\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue803\Endpoint\GetFiles($queryParameters, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
@@ -14,6 +14,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue810\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue810\Endpoint\MimeTypeGeneratedValidDocBlock($requestBody, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Issue823\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Issue823\Endpoint\GetApiUser2());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-823/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Issue828\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Issue828\Endpoint\TestSimpleClassArray($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
@@ -41,6 +41,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ModelInResponse\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ModelInResponse\Endpoint\GetTestList());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\ModelTypeReference\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\MultiResources\Runt
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\MultiResources\Endpoint\ProducesTriggersAcceptBeingSet());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Api1\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Api2\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Endpoint\PostFileDeposit($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\MultipartNestedObje
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\MultipartNestedObject\Endpoint\PostFile($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\NoOperationIdWithDo
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\NoOperationIdWithDotPath\Endpoint\PostMessageM70047($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\NoReferenceBody\Run
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\NoReferenceBody\Endpoint\Test($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\NoReferenceResponse
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\NoReferenceResponse\Endpoint\Test());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Client.php
@@ -132,6 +132,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Operations\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Operations\Endpoint\PostNo200Thing());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
@@ -16,6 +16,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ParameterTypeRefere
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ParameterTypeReference\Endpoint\Foo($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
@@ -19,6 +19,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ParametersMapKeys\R
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ParametersMapKeys\Endpoint\GetOrder($orderId, $queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -158,6 +158,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Parameters\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Parameters\Endpoint\TestFormExplodeQuery($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\ReadOnlyProperties\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
@@ -25,6 +25,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ReferencedRequestBo
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ReferencedRequestBodies\Endpoint\PatchParentsByParentIdChildChildId($parentId, $childId, $requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ResponseReferenceWi
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ResponseReferenceWithSchemaReference\Endpoint\Test());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ResponseReference\R
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ResponseReference\Endpoint\TestRefArray());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ResponseTypeReferen
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ResponseTypeReference\Endpoint\Foo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\RuntimeBoilerplate;
 
 class Client extends \Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
@@ -68,6 +68,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ScalarResponse\Runt
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ScalarResponse\Endpoint\GetNullableInteger());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Client.php
@@ -16,6 +16,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\SimplePathArrayPara
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\SimplePathArrayParameter\Endpoint\TestSimplePathArrayParameters($string, $array, $stringRef, $arrayRef));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\SkipNullValues\Runt
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\SkipNullValues\Endpoint\TestNullableQueryParameters($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -21,6 +21,10 @@ class Client extends \Jane\OpenApi3\Tests\Expected\SkipParameterCheck\Runtime\Cl
     {
         return $this->executeEndpoint(new \Jane\OpenApi3\Tests\Expected\SkipParameterCheck\Endpoint\TestGetWithPathParameters($testPath, $queryParameters, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\TestNullableArray\R
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\TestNullableArray\Endpoint\TestNullableArray());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\TestNullable\Runtim
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\TestNullable\Endpoint\TestNullableQueryParameters($queryParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
@@ -14,6 +14,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\ThrowUnexceptedStat
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\ThrowUnexceptedStatusCode\Endpoint\PostFoo($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected.manifest.json
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected.manifest.json
@@ -1,7 +1,7 @@
 {
     "algorithm": "sha256",
     "files": {
-        "Client.php": "e73ff0b2f0f67440fea2eabbe99d2e53cddec92ba6d1c35d2ad99d63a77a4e75",
+        "Client.php": "c97dfaa72eb1ae2e541b28a74d12ddc9af4cc1607f87f49d52a0521d5cc002e3",
         "Endpoint/AddOrDeleteRules.php": "3d5d9ceb21782500dabe962f9c374c71c1e3d822245e40a540025f3cab13203c",
         "Endpoint/FindPrivateTweetMetricsById.php": "7ef68706398cb3ebd995e1a5869f1bf2fb03ef5951d0e5b4b60c6d6a7cfdaaa3",
         "Endpoint/FindTweetsById.php": "bff59737c5b7b4b5b6517f1f1151b644ffb11177d2aee044e987cff62ec39ea6",

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\UppercaseParameter\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\UppercaseParameter\Endpoint\TestGetWithUppercasePathParameters($testParameter));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi3\Tests\Expected\UseCacheableSupportsMethod;
 
 class Client extends \Jane\Component\OpenApi3\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\UseCacheableSupportsMethod\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Client.php
@@ -22,6 +22,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\VndPlusJson\Runtime
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\VndPlusJson\Endpoint\ListSponsoredProductsCampaigns($requestBody, $headerParameters));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -36,6 +36,10 @@ class Client extends \Jane\OpenApi3\Tests\Expected\WhitelistedPathsArrayNotation
     {
         return $this->executeEndpoint(new \Jane\OpenApi3\Tests\Expected\WhitelistedPathsArrayNotation\Endpoint\AddOrDeleteRules($requestBody, $queryParameters, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Client.php
@@ -20,6 +20,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsCir
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsCircularReference\Endpoint\GetBaz());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsRef
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsReferenceWithoutContent\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsReq
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPathsRequestBodyReference\Endpoint\PostFoo($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -36,6 +36,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPaths\Ru
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\WhitelistedPaths\Endpoint\AddOrDeleteRules($requestBody, $queryParameters, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
@@ -28,6 +28,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\XNamespace\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\XNamespace\Endpoint\Ops\Monitoring\GetTaggedItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Yaml\Runtime\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Yaml\Endpoint\TestReferenceResponse());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation;
 
 class Client extends \Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\ArrayItemsValidation\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\CustomValidators\R
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\CustomValidators\Endpoint\GetPrice());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi31\Tests\DefaultAdditionalProps;
 
 class Client extends \Jane\Component\OpenApi31\Tests\DefaultAdditionalProps\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\DefaultAdditionalProps\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/default-additional-properties-false/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi31\Tests\DiscriminatorExpected;
 
 class Client extends \Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\DiscriminatorExpected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/discriminator/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\EnumAsObjects\Runtime\Clien
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\EnumAsObjects\Endpoint\GetItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\GenerateErrorExcep
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\GenerateErrorExceptions\Endpoint\GetUser());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Issue1006\Runtime\Client\Cl
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Issue1006\Endpoint\CreateWidget($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1006/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue1007\Runtime\
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue1007\Endpoint\GetThings());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1007/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Client.php
@@ -13,6 +13,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\ExpectedIssue1036\Endpoint\UploadDocument($requestBody));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-1036/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue869\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue869\Endpoint\GetMessage());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue939\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue939\Endpoint\GetProposal());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue940\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue940\Endpoint\GetProposal());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Client.php
@@ -21,6 +21,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue946\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue946\Endpoint\GetEntity($id));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
@@ -14,6 +14,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue963\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue963\Endpoint\GetMemberBySelector($selector, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue966\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue966\Endpoint\GetOrder());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Issue968\Runtime\C
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Issue968\Endpoint\GetReport());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
@@ -118,6 +118,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Museum\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Museum\Endpoint\GetTicketCode($ticketId, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\NullableAllofInOne
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\NullableAllofInOneof\Endpoint\GetItem());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
@@ -12,6 +12,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\NullableDate\Runti
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\NullableDate\Endpoint\GetEvents());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Client.php
@@ -4,6 +4,10 @@ namespace Jane\Component\OpenApi31\Tests\RuntimeBoilerplate;
 
 class Client extends \Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\Client\Client
 {
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\RuntimeBoilerplate\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the fetch mode of the endpoint: a FetchMode value ('lazy' by default
+     * on GET/HEAD operations, 'eager' on every other verb).
+     */
+    public function getFetchMode(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform an HTTP response into a different object.
+     *
+     * Implementations may vary depending on the status code of the response.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/runtime-boilerplate/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
@@ -137,6 +137,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\ScalarGalaxy\Runti
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\ScalarGalaxy\Endpoint\GetMe($accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
@@ -33,6 +33,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Simple\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Simple\Endpoint\ShowPetById($petId));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
@@ -15,6 +15,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Endpoint\GetFoo());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
@@ -138,6 +138,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\TrainTravel\Runtim
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\TrainTravel\Endpoint\CreateBookingPayment($bookingId, $requestBody, $accept));
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
@@ -28,6 +28,10 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\XNamespace\Runtime
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\XNamespace\Endpoint\Ops\Monitoring\GetTaggedItems());
     }
+    /**
+     * @param list<callable(\Symfony\Contracts\HttpClient\HttpClientInterface): \Symfony\Contracts\HttpClient\HttpClientInterface> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator
+     * @param list<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $additionalNormalizers
+     */
     public static function create(?\Symfony\Contracts\HttpClient\HttpClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
         $plugins = [];

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -44,6 +44,9 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
         $mapped = [];
         foreach ($responses as $response) {
             $mapped[] = $response instanceof Result ? $response->getResponse() : $response;

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/FormEncoder.php
@@ -22,6 +22,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
     }
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
         return $result;
     }

--- a/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
@@ -6,6 +6,7 @@ use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Registry\Schema;
 use Jane\Component\JsonSchema\Registry\Schema as BaseSchema;
+use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -15,6 +16,8 @@ use PhpParser\Node\Stmt;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -51,6 +54,13 @@ trait ClientGenerator
                     $this->createSerializerStatement($context),
                     $this->createReturnStatement(),
                 ],
+            ], [
+                'comments' => [new Doc(implode("\n", [
+                    '/**',
+                    \sprintf(' * @param list<callable(\%1$s): \%1$s> $additionalPlugins HttpClientInterface decorator factories, applied left-to-right after the server URL decorator', HttpClientInterface::class),
+                    \sprintf(' * @param list<\%s|\%s> $additionalNormalizers', NormalizerInterface::class, DenormalizerInterface::class),
+                    ' */',
+                ]))],
             ]
         );
     }

--- a/src/Component/OpenApiCommon/Generator/Runtime/Client/Client.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/Client/Client.php
@@ -54,6 +54,10 @@ abstract class Client
      */
     public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
         $mapped = [];
 
         foreach ($responses as $response) {

--- a/src/Component/OpenApiCommon/Generator/Runtime/Client/FormEncoder.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/Client/FormEncoder.php
@@ -23,6 +23,7 @@ final class FormEncoder implements EncoderInterface, DecoderInterface
 
     public function decode(string $data, string $format, array $context = []): mixed
     {
+        $result = [];
         \parse_str($data, $result);
 
         return $result;

--- a/src/Component/OpenApiCommon/Generator/RuntimeGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/RuntimeGenerator.php
@@ -6,8 +6,14 @@ use Jane\Component\JsonSchema\Generator\RuntimeGenerator as BaseRuntimeGenerator
 
 class RuntimeGenerator extends BaseRuntimeGenerator
 {
+    /**
+     * The Client template types its endpoint methods with the Endpoint
+     * interface, which only endpoint generation requires otherwise: a
+     * specification without operations would get a Client referencing an
+     * interface that is never generated.
+     */
     private const OPENAPI_BUILDERS = [
-        'Client' => ['class' => 'Client', 'namespace' => ['Client'], 'source' => 'Client/Client.php', 'file' => 'Client.php'],
+        'Client' => ['class' => 'Client', 'namespace' => ['Client'], 'source' => 'Client/Client.php', 'file' => 'Client.php', 'requires' => ['Endpoint']],
         'BaseEndpoint' => ['class' => 'BaseEndpoint', 'namespace' => ['Client'], 'source' => 'Client/BaseEndpoint.php', 'file' => 'BaseEndpoint.php'],
         'Endpoint' => ['class' => 'Endpoint', 'namespace' => ['Client'], 'source' => 'Client/Endpoint.php', 'file' => 'Endpoint.php'],
         'EndpointTrait' => ['class' => 'EndpointTrait', 'namespace' => ['Client'], 'source' => 'Client/EndpointTrait.php', 'file' => 'EndpointTrait.php'],

--- a/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/ClientTest.php
+++ b/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/ClientTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Tests\Generator\Runtime\data\Client;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+// The real, namespace-less runtime templates are exercised directly: they are
+// the exact files copied into generated clients.
+if (!interface_exists('Endpoint', false) || !class_exists('Client', false)) {
+    $runtimeTemplateDir = __DIR__ . '/../../../../../Generator/Runtime/Client';
+
+    if (!interface_exists('Endpoint', false)) {
+        require_once $runtimeTemplateDir . '/Endpoint.php';
+    }
+
+    if (!class_exists('Client', false)) {
+        require_once $runtimeTemplateDir . '/Client.php';
+    }
+}
+
+final class ClientTest extends TestCase
+{
+    /**
+     * stream() accepts a single response as well as a batch. A single
+     * response must be streamed as itself, not iterated as an object.
+     */
+    public function testStreamingASingleResponseDrivesIt(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse('payload')]);
+        $client = $this->client($httpClient);
+        $response = $httpClient->request('GET', 'https://example.test/one');
+
+        self::assertSame([$response], $this->streamedResponses($client->stream($response)));
+    }
+
+    public function testStreamingABatchDrivesEveryResponse(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse('one'), new MockResponse('two')]);
+        $client = $this->client($httpClient);
+        $first = $httpClient->request('GET', 'https://example.test/one');
+        $second = $httpClient->request('GET', 'https://example.test/two');
+
+        self::assertSame([$first, $second], $this->streamedResponses($client->stream([$first, $second])));
+    }
+
+    private function client(MockHttpClient $httpClient): \Client
+    {
+        return new class($httpClient, new Serializer()) extends \Client {
+        };
+    }
+
+    /**
+     * The responses that reached their last chunk, in stream order.
+     *
+     * @return list<ResponseInterface>
+     */
+    private function streamedResponses(iterable $stream): array
+    {
+        $completed = [];
+
+        foreach ($stream as $response => $chunk) {
+            if ($chunk->isLast()) {
+                $completed[] = $response;
+            }
+        }
+
+        return $completed;
+    }
+}

--- a/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/FormEncoderTest.php
+++ b/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/FormEncoderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Tests\Generator\Runtime\data\Client;
+
+use PHPUnit\Framework\TestCase;
+
+// The real, namespace-less runtime template is exercised directly: it is the
+// exact file copied into generated clients.
+if (!class_exists('FormEncoder', false)) {
+    require_once __DIR__ . '/../../../../../Generator/Runtime/Client/FormEncoder.php';
+}
+
+final class FormEncoderTest extends TestCase
+{
+    public function testDecodesAQueryStringIntoAnArray(): void
+    {
+        self::assertSame(['a' => '1', 'b' => ['x', 'y']], (new \FormEncoder())->decode('a=1&b[]=x&b[]=y', 'form'));
+    }
+
+    public function testDecodesAnEmptyStringIntoAnEmptyArray(): void
+    {
+        self::assertSame([], (new \FormEncoder())->decode('', 'form'));
+    }
+
+    public function testEncodesAnArrayIntoAQueryString(): void
+    {
+        self::assertSame('a=1&b%5B0%5D=x', (new \FormEncoder())->encode(['a' => 1, 'b' => ['x']], 'form'));
+    }
+}

--- a/src/Component/OpenApiCommon/Tests/Generator/RuntimeGeneratorTest.php
+++ b/src/Component/OpenApiCommon/Tests/Generator/RuntimeGeneratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Tests\Generator;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Generator\File;
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Registry\Registry;
+use Jane\Component\JsonSchema\Registry\Schema;
+use Jane\Component\OpenApiCommon\Generator\RuntimeGenerator;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+final class RuntimeGeneratorTest extends TestCase
+{
+    /**
+     * The runtime Client's own template types its endpoint methods with the
+     * Endpoint interface, a dependency the client generator cannot see: a
+     * specification without operations otherwise gets a Client referencing an
+     * interface that is never generated.
+     */
+    public function testRequiringTheClientAlsoGeneratesTheEndpointInterface(): void
+    {
+        $schema = new Schema('openapi.json', 'Vendor\Api', '/tmp/generated', 'Client');
+        $schema->addRequiredRuntimeFile('Vendor\Api\Runtime\Client\Client');
+
+        $generator = new RuntimeGenerator(new Naming(), (new ParserFactory())->createForHostVersion());
+        $generator->generate($schema, 'Client', new Context(new Registry()));
+
+        $files = array_map(static fn (File $file): string => basename($file->getFilename()), $schema->getFiles());
+
+        self::assertContains('Client.php', $files);
+        self::assertContains('Endpoint.php', $files);
+    }
+}


### PR DESCRIPTION
The "runtime template family" of #1066 — one finding per generated client, three runtime template files. No
separate issue: the cluster is mechanical, except for one behaviour bug in unreleased 8.0 code that this PR
fixes with a test.

## What changed

- **`Client::stream()` streamed nothing for a single response.** The runtime template accepts
  `iterable|ResponseInterface` but ran `foreach` on the argument directly, so a single `ResponseInterface`
  was iterated as an object (its public properties) and the HTTP client's stream received an empty list. A
  single response is now wrapped. Test: `ClientTest` on the real template with Symfony's `MockHttpClient`,
  which fails on `next`.
- **Specifications without operations got a runtime `Client` referencing an `Endpoint` interface that is
  never generated** (20 fixtures): `EndpointGenerator` is the only require-site of `Endpoint`, while the
  Client template types `executeEndpoint()`, `executeRawEndpoint()` and `processEndpoint()` with it. The
  Client builder now declares `requires: ['Endpoint']`, the mechanism #1059 introduced for `ValidatorTrait`.
  Test: `RuntimeGeneratorTest` in OpenApiCommon.
- `Client::create()` now documents `$additionalPlugins` as
  `list<callable(HttpClientInterface): HttpClientInterface>` and `$additionalNormalizers` as normalizer
  instances, so the decorator loop is no longer a call on `mixed`; `FormEncoder::decode()` initialises the
  `parse_str()` output variable. Regression tests added for the encoder.
- Expected trees, the three manifests and the Mago baseline regenerated in the same commit.

## Baseline

| code | findings |
|---|---|
| `non-iterable-object-iteration` | 158 → 0 |
| `invalid-callable` | 158 → 0 |
| `reference-to-undefined-variable` | 158 → 0 |
| `invalid-method-access` | 240 → 0 |
| `unknown-match-subject-type`, `invalid-destructuring-source`, `unknown-iterator-type` | 20 each → 0 |
| `non-existent-class-like` | 178 → 118 |
| total | 41 683 → 40 849 findings, 13 725 → 13 151 entries |

The missing `Endpoint` interface explained more than #1066 credits it with: every `invalid-method-access`
finding in the baseline, plus the two 20-finding codes, were the runtime Client calling methods on an
unknown type.

## Left in the baseline: `unsafe-instantiation` (158) — your call

`create()` does `new static($httpClient, $serializer)` on a non-final class. The non-invasive fix,
`@phpstan-consistent-constructor` on the generated class, trips a Mago 1.47 bug: for a class that inherits
its constructor, the annotation makes Mago assume a zero-argument constructor and report 158
`too-many-arguments` errors instead (six-variant probe; the annotation on the abstract parent is ignored).
The only clean fix is `final public function __construct` on the runtime `Client` template. That is a
design decision — subclasses could no longer redefine the constructor, `create()` overrides stay possible —
so it is not in this PR. Say the word and I add it here for 8.0; otherwise the finding stays baselined.

## Checks

- `phpunit` on `src/Component/OpenApiCommon/Tests` (96 tests, including the three new files) and on the
  fixture suites of OpenApi2 / OpenApi3 / OpenApi31
- `castor qa:mago:generated` — no issues against the regenerated baseline
- `php-cs-fixer` on the touched files

---

Prepared with an AI agent (Claude Code); I use Jane-generated clients in a production codebase; the numbers
are from the committed baseline before and after this change, the `stream()` behaviour was verified with a
test before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Nu3S23wfUgPAbiH8gR8Lt