### PR TITLE
Prepare v7.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.14.1] - 2026-09-07
+### Fixed
+- [JsonSchema] [GH#559](https://github.com/janephp/janephp/issues/559) Guard nested collection loops against `null` entries: a collection (map/array) whose item type is itself a nullable collection generated a nested `foreach` without a null check, crashing with `foreach() argument must be of type array|object, null given` on valid payloads (e.g. a Docker PortMap containing `"9000/tcp": null`). Generated loops now assign `null` for such entries and continue, on both denormalization and normalization, and only when the item schema declares nullability (`x-nullable` / `nullable` / type containing `null`)
+
 ## [7.14.0] - 2026-08-31
 ### Added
 - [JsonSchema] [OpenApi] New `default-additional-properties` option: decides how a schema that leaves `additionalProperties` unspecified is treated, across every component. `null` (default) keeps each component's own behavior — closed models for the JsonSchema component and OpenAPI 2, open models (unknown keys captured through the `AdditionalAndPatternProperties` trait) for OpenAPI 3 / 3.1; `true` treats unspecified `additionalProperties` as open everywhere; `false` treats it as closed everywhere, letting users keep closed models without editing their specification when migrating from older Jane versions where unspecified meant closed. An explicit `additionalProperties` value in the specification always wins over the option. The generated Symfony validation `Collection` constraint (`allowExtraFields`) follows the same resolution: while the option is unset it keeps its previous behavior (extra fields allowed for schemas without `additionalProperties` / `patternProperties`), and once the option is set — or the specification sets `additionalProperties: false` — it matches the generated model
@@ -960,7 +964,8 @@ See :
 * https://github.com/janephp/jane/releases
 * https://github.com/janephp/openapi/releases
 
-[Unreleased]: https://github.com/janephp/janephp/compare/v7.14.0...HEAD
+[Unreleased]: https://github.com/janephp/janephp/compare/v7.14.1...HEAD
+[7.14.1]: https://github.com/janephp/janephp/compare/v7.14.0...v7.14.1
 [7.14.0]: https://github.com/janephp/janephp/compare/v7.13.0...v7.14.0
 [7.13.0]: https://github.com/janephp/janephp/compare/v7.12.0...v7.13.0
 [7.12.0]: https://github.com/janephp/janephp/compare/v7.11.2...v7.12.0


### PR DESCRIPTION
Prepare the v7.14.1 release on the `7.x` branch.

### Fixed
- [JsonSchema] guard nested collection loops against `null` entries — collections (maps/arrays) whose item type is itself a nullable collection generated a nested `foreach` without a null check, crashing with `foreach() argument must be of type array|object, null given` on valid payloads like a Docker PortMap containing `"9000/tcp": null` ([PR #1069](https://github.com/janephp/janephp/pull/1069), fixes [GH#559](https://github.com/janephp/janephp/issues/559))