### PR TITLE
ci(gitsplit): split the 7.x branch into component repositories

### DIFF
--- a/.github/gitsplit/7-plus/.gitsplit.yml
+++ b/.github/gitsplit/7-plus/.gitsplit.yml
@@ -34,4 +34,5 @@ splits:
 # List of references to split (defined as regexp)
 origins:
   - ^next$
+  - ^7\.x$
   - ^v[7]+\.\d+\.\d+$

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - next
+      - 7.x
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - next
+      - 7.x
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
Allow the `7.x` branch to be gitsplit into the component repositories and run CI on it.

- `.github/gitsplit/7-plus/.gitsplit.yml`: add `^7\.x$` to `origins` (component repos will get their own `7.x` branch)
- `.github/workflows/gitsplit.yml`: trigger the gitsplit workflow on pushes to `7.x`, not only `next` (and on `v7.*.*` release publishes, as before)
- `.github/workflows/ci.yml`: run CI (cs / phpstan / tests) on pushes to `7.x` — until now it only ran on `next` pushes (PRs already ran it via the unfiltered `pull_request` trigger)