### PR TITLE
fix(open-api): encode nested query parameter keys once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [OpenApi] The runtime `BaseEndpoint` no longer percent-encodes nested query parameter keys twice. `encodeArrayValue()`, `encodeFormStyle()` and `flattenBracketPairs()` pre-encoded each sub-key before appending it to the bracketed key, which `encodeStringValue()` / `encodeIntValue()` then encoded again: a sub-key containing a reserved character was emitted as `queryParam%5Bunit%253Amm%5D=width` instead of `queryParam%5Bunit%3Amm%5D=width`, so after the server's own URL-decoding the sub-key arrived as the literal string `unit%3Amm` rather than `unit:mm`. Sub-keys are now appended raw and encoded once, by the single `rawurlencode()` of the assembled key, matching `http_build_query(..., PHP_QUERY_RFC3986)`. Regressed in 7.14.0 for `style` / `explode` / `deepObject` parameters and in 7.10.4 ([GH#907](https://github.com/janephp/janephp/pull/907), [GH#908](https://github.com/janephp/janephp/pull/908)) for bracketed arrays; keys made only of unreserved characters are unaffected
 
 ## [7.14.1] - 2026-09-07
 ### Fixed

--- a/src/Component/OpenApiCommon/Generator/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/Client/BaseEndpoint.php
@@ -181,7 +181,7 @@ abstract class BaseEndpoint implements Endpoint
         $params = [];
 
         foreach ($value as $subKey => $subValue) {
-            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $arrayKey = $queryParamName . '[' . $subKey . ']';
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
 
@@ -230,7 +230,7 @@ abstract class BaseEndpoint implements Endpoint
             foreach ($value as $index => $item) {
                 if (\is_array($item)) {
                     // Nested levels use bracket notation.
-                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . $index . ']', $item, $allowReserved));
 
                     continue;
                 }
@@ -248,7 +248,7 @@ abstract class BaseEndpoint implements Endpoint
         // Exploded objects drop the parent key: each property becomes a top level pair.
         foreach ($value as $subKey => $subValue) {
             if (\is_array($subValue)) {
-                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                $pairs = array_merge($pairs, $this->flattenBracketPairs((string) $subKey, $subValue, $allowReserved));
 
                 continue;
             }
@@ -315,7 +315,7 @@ abstract class BaseEndpoint implements Endpoint
         $pairs = [];
         foreach ($value as $subKey => $subValue) {
             $pairs = array_merge($pairs, $this->flattenBracketPairs(
-                $prefix . '[' . rawurlencode((string) $subKey) . ']',
+                $prefix . '[' . $subKey . ']',
                 $subValue,
                 $allowReserved
             ));

--- a/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/BaseEndpointTest.php
+++ b/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/BaseEndpointTest.php
@@ -100,7 +100,7 @@ if (!class_exists('BaseEndpoint', false)) {
         private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string {
             $params = [];
             foreach ($value as $subKey => $subValue) {
-                $arrayKey = $queryParamName . "[" . rawurlencode((string) $subKey) . "]";
+                $arrayKey = $queryParamName . "[" . $subKey . "]";
                 $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
             }
             return implode("&", $params);
@@ -123,14 +123,14 @@ if (!class_exists('BaseEndpoint', false)) {
             $pairs = [];
             if (array_is_list($value)) {
                 foreach ($value as $index => $item) {
-                    if (is_array($item)) { $pairs = array_merge($pairs, $this->flattenBracketPairs($name . "[" . rawurlencode((string) $index) . "]", $item, $allowReserved)); continue; }
+                    if (is_array($item)) { $pairs = array_merge($pairs, $this->flattenBracketPairs($name . "[" . $index . "]", $item, $allowReserved)); continue; }
                     if (null === $item) { continue; }
                     $pairs[] = $this->encodeValue($name, $item, $allowReserved);
                 }
                 return $pairs;
             }
             foreach ($value as $subKey => $subValue) {
-                if (is_array($subValue)) { $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved)); continue; }
+                if (is_array($subValue)) { $pairs = array_merge($pairs, $this->flattenBracketPairs((string) $subKey, $subValue, $allowReserved)); continue; }
                 if (null === $subValue) { continue; }
                 $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
             }
@@ -149,7 +149,7 @@ if (!class_exists('BaseEndpoint', false)) {
         private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array {
             if (!is_array($value)) { if (null === $value) { return []; } return [$this->encodeValue($prefix, $value, $allowReserved)]; }
             $pairs = [];
-            foreach ($value as $subKey => $subValue) { $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . "[" . rawurlencode((string) $subKey) . "]", $subValue, $allowReserved)); }
+            foreach ($value as $subKey => $subValue) { $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . "[" . $subKey . "]", $subValue, $allowReserved)); }
             return $pairs;
         }
         private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string {
@@ -190,6 +190,9 @@ final class BaseEndpointTest extends TestCase
         yield 'int array' => [['queryParam' => [1, 2, 3]], 'queryParam%5B0%5D=1&queryParam%5B1%5D=2&queryParam%5B2%5D=3'];
         yield 'array with string keys' => [['queryParam' => ['key' => 1]], 'queryParam%5Bkey%5D=1'];
         yield 'nested array' => [['queryParam' => ['key' => ['test' => 'test1']]], 'queryParam%5Bkey%5D%5Btest%5D=test1'];
+        yield 'array with a reserved character in the key' => [['queryParam' => ['unit:mm' => 'width']], 'queryParam%5Bunit%3Amm%5D=width'];
+        yield 'array with a separator character in the key' => [['queryParam' => ['span&low' => 'ten']], 'queryParam%5Bspan%26low%5D=ten'];
+        yield 'nested array with reserved characters in the keys' => [['queryParam' => ['group:one' => ['unit:mm' => 'width']]], 'queryParam%5Bgroup%3Aone%5D%5Bunit%3Amm%5D=width'];
     }
 
     public static function queryParamsProviderWithAllowingReservedCharacters(): iterable
@@ -220,6 +223,11 @@ final class BaseEndpointTest extends TestCase
             ['search' => ['name' => 'john', 'address' => ['city' => 'NY']]],
             ['search' => ['style' => 'form', 'explode' => true]],
             'name=john&address%5Bcity%5D=NY',
+        ];
+        yield 'form exploded object with a reserved character in the nested key' => [
+            ['layout' => ['group:one' => ['unit:mm' => 'width']]],
+            ['layout' => ['style' => 'form', 'explode' => true]],
+            'group%3Aone%5Bunit%3Amm%5D=width',
         ];
         yield 'form exploded array of objects uses bracket notation' => [
             ['points' => [['x' => 1], ['x' => 2]]],
@@ -255,6 +263,21 @@ final class BaseEndpointTest extends TestCase
             ['filter' => ['range' => ['from' => 'a']]],
             ['filter' => ['style' => 'deepObject', 'explode' => true]],
             'filter%5Brange%5D%5Bfrom%5D=a',
+        ];
+        yield 'deep object with a reserved character in the key' => [
+            ['bounds' => ['unit:mm' => 'width']],
+            ['bounds' => ['style' => 'deepObject', 'explode' => true]],
+            'bounds%5Bunit%3Amm%5D=width',
+        ];
+        yield 'deep object with a separator character in the key' => [
+            ['bounds' => ['span&low' => 'ten']],
+            ['bounds' => ['style' => 'deepObject', 'explode' => true]],
+            'bounds%5Bspan%26low%5D=ten',
+        ];
+        yield 'deep object nested with reserved characters in the keys' => [
+            ['bounds' => ['group:one' => ['unit:mm' => 'width']]],
+            ['bounds' => ['style' => 'deepObject', 'explode' => true]],
+            'bounds%5Bgroup%3Aone%5D%5Bunit%3Amm%5D=width',
         ];
         yield 'null value is omitted' => [
             ['search' => null, 'other' => 'kept'],


### PR DESCRIPTION
encodeArrayValue(), encodeFormStyle() and flattenBracketPairs() rawurlencode()-ed each sub-key before appending it to the bracketed key, which encodeStringValue() / encodeIntValue() then rawurlencode()-ed again. A sub-key holding a reserved character was emitted as queryParam%5Bunit%253Amm%5D=width instead of queryParam%5Bunit%3Amm%5D=width, so the server saw the literal sub-key unit%3Amm.

Sub-keys are now appended raw and encoded once, by the single rawurlencode() of the assembled key, matching http_build_query(..., PHP_QUERY_RFC3986).

Regressed in 7.14.0 for style/explode/deepObject parameters and in 7.10.4 (GH#907, GH#908) for bracketed arrays. Keys made only of unreserved characters are unaffected.